### PR TITLE
Replace shortid to nanoid

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2,7 +2,22 @@
   "name": "instructure-icons",
   "version": "4.3.1",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
+    "@instructure/conventional-changelog": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@instructure/conventional-changelog/-/conventional-changelog-1.0.0.tgz",
+      "integrity": "sha512-1VKtL8vi7uQ7Gyl8GG1Neki5Fe1sXFhfo92DfgeNLQw2CKd9ufyoVydIWxKeGZGRQdNz05aXOZZCzhUb1j7rrw==",
+      "dev": true,
+      "requires": {
+        "conventional-commit-types": "2.2.0",
+        "lodash.map": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
+        "longest": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+        "pad-right": "0.2.2",
+        "right-pad": "1.0.1",
+        "word-wrap": "1.2.3"
+      }
+    },
     "abab": {
       "version": "https://registry.npmjs.org/abab/-/abab-1.0.3.tgz",
       "integrity": "sha1-uB3l9ydOxOdW15fNg08wNkJyTl0=",
@@ -16,7 +31,11 @@
     "accepts": {
       "version": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
       "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+        "negotiator": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
+      }
     },
     "acorn": {
       "version": "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz",
@@ -27,6 +46,9 @@
       "version": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
       "integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
       "dev": true,
+      "requires": {
+        "acorn": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz"
+      },
       "dependencies": {
         "acorn": {
           "version": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
@@ -39,6 +61,9 @@
       "version": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz",
       "integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
       "dev": true,
+      "requires": {
+        "acorn": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz"
+      },
       "dependencies": {
         "acorn": {
           "version": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
@@ -51,12 +76,24 @@
       "version": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
+      "requires": {
+        "acorn": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz"
+      },
       "dependencies": {
         "acorn": {
           "version": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
           "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
           "dev": true
         }
+      }
+    },
+    "acorn-object-spread": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-object-spread/-/acorn-object-spread-1.0.0.tgz",
+      "integrity": "sha1-SOrQ9KjrFplaF6Dbn/xqyq2kumg=",
+      "dev": true,
+      "requires": {
+        "acorn": "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz"
       }
     },
     "after": {
@@ -67,7 +104,11 @@
     "ajv": {
       "version": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
       "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "co": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+        "json-stable-stringify": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
+      }
     },
     "ajv-keywords": {
       "version": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
@@ -77,7 +118,12 @@
     "align-text": {
       "version": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+        "longest": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+        "repeat-string": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+      }
     },
     "alphanum-sort": {
       "version": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
@@ -92,7 +138,10 @@
     "ansi-cyan": {
       "version": "https://registry.npmjs.org/ansi-cyan/-/ansi-cyan-0.1.1.tgz",
       "integrity": "sha1-U4rlKK+JgvKK4w2G8vF0VtJgmHM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-wrap": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz"
+      }
     },
     "ansi-escapes": {
       "version": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
@@ -102,7 +151,10 @@
     "ansi-red": {
       "version": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
       "integrity": "sha1-jGOPnRCAgAo1PJwoyKgcpHBdlGw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-wrap": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz"
+      }
     },
     "ansi-regex": {
       "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -126,7 +178,11 @@
     "anymatch": {
       "version": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
       "integrity": "sha1-o+Uvo5FoyCX/V7AkgSbOWo/5VQc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "arrify": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+        "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz"
+      }
     },
     "aproba": {
       "version": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz",
@@ -141,22 +197,35 @@
     "are-we-there-yet": {
       "version": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
       "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "delegates": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz"
+      }
     },
     "argparse": {
       "version": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "sprintf-js": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+      }
     },
     "aria-query": {
       "version": "https://registry.npmjs.org/aria-query/-/aria-query-0.3.0.tgz",
       "integrity": "sha1-y4qZhOKGJxHIPICt5bj1yg3itGc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ast-types-flow": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz"
+      }
     },
     "arr-diff": {
       "version": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz"
+      }
     },
     "arr-flatten": {
       "version": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
@@ -188,6 +257,12 @@
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
       "dev": true
     },
+    "array-ify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
+      "integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=",
+      "dev": true
+    },
     "array-slice": {
       "version": "https://registry.npmjs.org/array-slice/-/array-slice-1.0.0.tgz",
       "integrity": "sha1-5zA08A3MH0CHYAj9IP6ud71LfC8=",
@@ -196,7 +271,10 @@
     "array-union": {
       "version": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-uniq": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz"
+      }
     },
     "array-uniq": {
       "version": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
@@ -211,7 +289,11 @@
     "array.prototype.find": {
       "version": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.0.4.tgz",
       "integrity": "sha1-VWpcU2LAhkgyPdrrnenRS8GGTJA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "define-properties": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+        "es-abstract": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.7.0.tgz"
+      }
     },
     "arraybuffer.slice": {
       "version": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
@@ -235,16 +317,30 @@
     "asn1.js": {
       "version": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
       "integrity": "sha1-SLokC0WpKA6UdImQull9IWYX/UA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "bn.js": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.7.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "minimalistic-assert": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
+      }
     },
     "assert": {
       "version": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
       "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "util": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
+      }
     },
     "assert-plus": {
       "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
       "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+      "dev": true
+    },
+    "ast-types": {
+      "version": "0.9.12",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.12.tgz",
+      "integrity": "sha1-sTYwDWcCZiWuFTJpgsqZGOXbc8k=",
       "dev": true
     },
     "ast-types-flow": {
@@ -275,7 +371,15 @@
     "autoprefixer": {
       "version": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
       "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "browserslist": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+        "caniuse-db": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000696.tgz",
+        "normalize-range": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+        "num2fraction": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz",
+        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
+      }
     },
     "aws-sign2": {
       "version": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
@@ -290,7 +394,10 @@
     "axios": {
       "version": "https://registry.npmjs.org/axios/-/axios-0.16.1.tgz",
       "integrity": "sha1-wLbSZgCEI4S49QnlcRHw0t+CI8o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "follow-redirects": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.2.4.tgz"
+      }
     },
     "babel": {
       "version": "https://registry.npmjs.org/babel/-/babel-6.23.0.tgz",
@@ -300,112 +407,247 @@
     "babel-code-frame": {
       "version": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
       "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+        "js-tokens": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+      }
     },
     "babel-core": {
       "version": "https://registry.npmjs.org/babel-core/-/babel-core-6.24.1.tgz",
       "integrity": "sha1-jEKFZNzh4fQfszfsNPTDsCK1rYM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+        "babel-generator": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.25.0.tgz",
+        "babel-helpers": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+        "babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+        "babel-register": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+        "babylon": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz",
+        "convert-source-map": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+        "json5": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+        "private": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
+        "slash": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+      }
     },
     "babel-eslint": {
       "version": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-7.2.1.tgz",
       "integrity": "sha1-B5Qi63O6gR48oIZc6Hrykyf4xS8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+        "babylon": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
+      }
     },
     "babel-generator": {
       "version": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.25.0.tgz",
       "integrity": "sha1-M6GvcNXyiQrrRlpKd5PB32qeqfw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+        "detect-indent": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+        "jsesc": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+        "trim-right": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
+      }
     },
     "babel-helper-bindify-decorators": {
       "version": "https://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.24.1.tgz",
       "integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz"
+      }
     },
     "babel-helper-builder-binary-assignment-operator-visitor": {
       "version": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
       "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-explode-assignable-expression": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz"
+      }
     },
     "babel-helper-builder-react-jsx": {
       "version": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.24.1.tgz",
       "integrity": "sha1-CteRfjPI11HmRtrKTnfMGTd9LLw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+        "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+      }
     },
     "babel-helper-call-delegate": {
       "version": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-hoist-variables": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz"
+      }
     },
     "babel-helper-define-map": {
       "version": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz",
       "integrity": "sha1-epdH8ljYlH0y1RX2qhx70CIEoIA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+      }
     },
     "babel-helper-explode-assignable-expression": {
       "version": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
       "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz"
+      }
     },
     "babel-helper-explode-class": {
       "version": "https://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.24.1.tgz",
       "integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-bindify-decorators": "https://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.24.1.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz"
+      }
     },
     "babel-helper-function-name": {
       "version": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-get-function-arity": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz"
+      }
     },
     "babel-helper-get-function-arity": {
       "version": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz"
+      }
     },
     "babel-helper-hoist-variables": {
       "version": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz"
+      }
     },
     "babel-helper-optimise-call-expression": {
       "version": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
       "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz"
+      }
     },
     "babel-helper-regex": {
       "version": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
       "integrity": "sha1-024i+rEAjXnYhkjjIRaGgShFbOg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+      }
     },
     "babel-helper-remap-async-to-generator": {
       "version": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz"
+      }
     },
     "babel-helper-replace-supers": {
       "version": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
       "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-optimise-call-expression": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+        "babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz"
+      }
     },
     "babel-helpers": {
       "version": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz"
+      }
     },
     "babel-loader": {
       "version": "https://registry.npmjs.org/babel-loader/-/babel-loader-6.4.1.tgz",
       "integrity": "sha1-CzQRLVsHSKjc2/Uaz2+b1C1QuMo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "find-cache-dir": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
+        "loader-utils": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+      }
     },
     "babel-messages": {
       "version": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+      }
     },
     "babel-plugin-check-es2015-constants": {
       "version": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+      }
     },
     "babel-plugin-syntax-async-functions": {
       "version": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
@@ -470,222 +712,509 @@
     "babel-plugin-transform-async-generator-functions": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz",
       "integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-remap-async-to-generator": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
+        "babel-plugin-syntax-async-generators": "https://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+      }
     },
     "babel-plugin-transform-async-to-generator": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-remap-async-to-generator": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
+        "babel-plugin-syntax-async-functions": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+      }
     },
     "babel-plugin-transform-class-constructor-call": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-class-constructor-call/-/babel-plugin-transform-class-constructor-call-6.24.1.tgz",
       "integrity": "sha1-gNwoVQWsBn3LjWxl4vbxGrd2Xvk=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-class-constructor-call": "https://registry.npmjs.org/babel-plugin-syntax-class-constructor-call/-/babel-plugin-syntax-class-constructor-call-6.18.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz"
+      }
+    },
+    "babel-plugin-transform-class-display-name": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-display-name/-/babel-plugin-transform-class-display-name-0.0.3.tgz",
+      "integrity": "sha1-MujBlk7fStGRPzaKGlx5Bm/t3d0=",
       "dev": true
     },
     "babel-plugin-transform-class-properties": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
       "integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+        "babel-plugin-syntax-class-properties": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz"
+      }
     },
     "babel-plugin-transform-decorators": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.24.1.tgz",
       "integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-explode-class": "https://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.24.1.tgz",
+        "babel-plugin-syntax-decorators": "https://registry.npmjs.org/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz"
+      }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+      }
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
       "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+      }
     },
     "babel-plugin-transform-es2015-block-scoping": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
       "integrity": "sha1-dsKV3DpHQbFmWt/TFnIV3P8ypXY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+      }
     },
     "babel-plugin-transform-es2015-classes": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
       "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-define-map": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz",
+        "babel-helper-function-name": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+        "babel-helper-optimise-call-expression": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+        "babel-helper-replace-supers": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+        "babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz"
+      }
     },
     "babel-plugin-transform-es2015-computed-properties": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz"
+      }
     },
     "babel-plugin-transform-es2015-destructuring": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+      }
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
       "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz"
+      }
     },
     "babel-plugin-transform-es2015-for-of": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
       "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+      }
     },
     "babel-plugin-transform-es2015-function-name": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz"
+      }
     },
     "babel-plugin-transform-es2015-literals": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
       "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+      }
     },
     "babel-plugin-transform-es2015-modules-amd": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
       "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-es2015-modules-commonjs": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz"
+      }
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
       "integrity": "sha1-0+MQtA72ZKNmIiAAl8bUQCmPK/4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-strict-mode": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz"
+      }
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
       "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-hoist-variables": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz"
+      }
     },
     "babel-plugin-transform-es2015-modules-umd": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
       "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-es2015-modules-amd": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz"
+      }
     },
     "babel-plugin-transform-es2015-object-super": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
       "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-replace-supers": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+      }
     },
     "babel-plugin-transform-es2015-parameters": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-call-delegate": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+        "babel-helper-get-function-arity": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz"
+      }
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz"
+      }
     },
     "babel-plugin-transform-es2015-spread": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+      }
     },
     "babel-plugin-transform-es2015-sticky-regex": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-regex": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz"
+      }
     },
     "babel-plugin-transform-es2015-template-literals": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+      }
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
       "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+      }
     },
     "babel-plugin-transform-es2015-unicode-regex": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-regex": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+        "regexpu-core": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz"
+      }
     },
     "babel-plugin-transform-exponentiation-operator": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
       "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-builder-binary-assignment-operator-visitor": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
+        "babel-plugin-syntax-exponentiation-operator": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+      }
     },
     "babel-plugin-transform-export-extensions": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-export-extensions/-/babel-plugin-transform-export-extensions-6.22.0.tgz",
       "integrity": "sha1-U3OLR+deghhYnuqUbLvTkQm75lM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-export-extensions": "https://registry.npmjs.org/babel-plugin-syntax-export-extensions/-/babel-plugin-syntax-export-extensions-6.13.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+      }
     },
     "babel-plugin-transform-flow-strip-types": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
       "integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-flow": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+      }
     },
     "babel-plugin-transform-object-rest-spread": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.23.0.tgz",
       "integrity": "sha1-h11ryb52HFiirj/u5dxIldjH+SE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-object-rest-spread": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+      }
     },
     "babel-plugin-transform-react-display-name": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
       "integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+      }
     },
     "babel-plugin-transform-react-jsx": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz",
       "integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-builder-react-jsx": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.24.1.tgz",
+        "babel-plugin-syntax-jsx": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+      }
     },
     "babel-plugin-transform-react-jsx-self": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz",
       "integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-jsx": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+      }
     },
     "babel-plugin-transform-react-jsx-source": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
       "integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-jsx": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+      }
     },
     "babel-plugin-transform-regenerator": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
       "integrity": "sha1-uNowWtQ8PJm0hI5P5AN7dw0jxBg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "regenerator-transform": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz"
+      }
     },
     "babel-plugin-transform-strict-mode": {
       "version": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz"
+      }
+    },
+    "babel-polyfill-loader": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/babel-polyfill-loader/-/babel-polyfill-loader-1.0.1.tgz",
+      "integrity": "sha512-EyaTCHsJJMFGcOAlVIhFGZvk7Nu5phSMuqtaYnaE1R4/nGZO6cbb9qBvdbLLiXoqRVUVZYdkzB/OfDKEPIlL8A==",
+      "dev": true,
+      "requires": {
+        "core-js-builder": "2.5.1",
+        "loader-utils": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz"
+      }
     },
     "babel-preset-env": {
       "version": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.3.3.tgz",
       "integrity": "sha1-WRNAd4Tj2Y3iqoFKPvkFlyKzTgs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-plugin-check-es2015-constants": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+        "babel-plugin-syntax-trailing-function-commas": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
+        "babel-plugin-transform-async-to-generator": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
+        "babel-plugin-transform-es2015-arrow-functions": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+        "babel-plugin-transform-es2015-block-scoped-functions": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+        "babel-plugin-transform-es2015-block-scoping": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
+        "babel-plugin-transform-es2015-classes": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+        "babel-plugin-transform-es2015-computed-properties": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+        "babel-plugin-transform-es2015-destructuring": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+        "babel-plugin-transform-es2015-duplicate-keys": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+        "babel-plugin-transform-es2015-for-of": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+        "babel-plugin-transform-es2015-function-name": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+        "babel-plugin-transform-es2015-literals": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+        "babel-plugin-transform-es2015-modules-amd": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+        "babel-plugin-transform-es2015-modules-commonjs": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
+        "babel-plugin-transform-es2015-modules-systemjs": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+        "babel-plugin-transform-es2015-modules-umd": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+        "babel-plugin-transform-es2015-object-super": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+        "babel-plugin-transform-es2015-parameters": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+        "babel-plugin-transform-es2015-shorthand-properties": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+        "babel-plugin-transform-es2015-spread": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+        "babel-plugin-transform-es2015-sticky-regex": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+        "babel-plugin-transform-es2015-template-literals": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+        "babel-plugin-transform-es2015-typeof-symbol": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+        "babel-plugin-transform-es2015-unicode-regex": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+        "babel-plugin-transform-exponentiation-operator": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
+        "babel-plugin-transform-regenerator": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
+        "browserslist": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+        "invariant": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz"
+      }
+    },
+    "babel-preset-es2015": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
+      "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-check-es2015-constants": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+        "babel-plugin-transform-es2015-arrow-functions": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+        "babel-plugin-transform-es2015-block-scoped-functions": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+        "babel-plugin-transform-es2015-block-scoping": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
+        "babel-plugin-transform-es2015-classes": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+        "babel-plugin-transform-es2015-computed-properties": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+        "babel-plugin-transform-es2015-destructuring": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+        "babel-plugin-transform-es2015-duplicate-keys": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+        "babel-plugin-transform-es2015-for-of": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+        "babel-plugin-transform-es2015-function-name": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+        "babel-plugin-transform-es2015-literals": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+        "babel-plugin-transform-es2015-modules-amd": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+        "babel-plugin-transform-es2015-modules-commonjs": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
+        "babel-plugin-transform-es2015-modules-systemjs": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+        "babel-plugin-transform-es2015-modules-umd": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+        "babel-plugin-transform-es2015-object-super": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+        "babel-plugin-transform-es2015-parameters": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+        "babel-plugin-transform-es2015-shorthand-properties": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+        "babel-plugin-transform-es2015-spread": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+        "babel-plugin-transform-es2015-sticky-regex": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+        "babel-plugin-transform-es2015-template-literals": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+        "babel-plugin-transform-es2015-typeof-symbol": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+        "babel-plugin-transform-es2015-unicode-regex": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+        "babel-plugin-transform-regenerator": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz"
+      }
     },
     "babel-preset-flow": {
       "version": "https://registry.npmjs.org/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz",
       "integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-flow-strip-types": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz"
+      }
     },
     "babel-preset-react": {
       "version": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.24.1.tgz",
       "integrity": "sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-jsx": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+        "babel-plugin-transform-react-display-name": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
+        "babel-plugin-transform-react-jsx": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz",
+        "babel-plugin-transform-react-jsx-self": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz",
+        "babel-plugin-transform-react-jsx-source": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
+        "babel-preset-flow": "https://registry.npmjs.org/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz"
+      }
     },
     "babel-preset-stage-1": {
       "version": "https://registry.npmjs.org/babel-preset-stage-1/-/babel-preset-stage-1-6.24.1.tgz",
       "integrity": "sha1-dpLNfc1oSZB+auSgqFWJz7niv7A=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-class-constructor-call": "https://registry.npmjs.org/babel-plugin-transform-class-constructor-call/-/babel-plugin-transform-class-constructor-call-6.24.1.tgz",
+        "babel-plugin-transform-export-extensions": "https://registry.npmjs.org/babel-plugin-transform-export-extensions/-/babel-plugin-transform-export-extensions-6.22.0.tgz",
+        "babel-preset-stage-2": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.24.1.tgz"
+      }
     },
     "babel-preset-stage-2": {
       "version": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.24.1.tgz",
       "integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-dynamic-import": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
+        "babel-plugin-transform-class-properties": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
+        "babel-plugin-transform-decorators": "https://registry.npmjs.org/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.24.1.tgz",
+        "babel-preset-stage-3": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz"
+      }
     },
     "babel-preset-stage-3": {
       "version": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz",
       "integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-trailing-function-commas": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
+        "babel-plugin-transform-async-generator-functions": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz",
+        "babel-plugin-transform-async-to-generator": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
+        "babel-plugin-transform-exponentiation-operator": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
+        "babel-plugin-transform-object-rest-spread": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.23.0.tgz"
+      }
     },
     "babel-register": {
       "version": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
       "integrity": "sha1-fhDhOi9xBlvfrVoXh7pFvKbe118=",
       "dev": true,
+      "requires": {
+        "babel-core": "https://registry.npmjs.org/babel-core/-/babel-core-6.24.1.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+        "core-js": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+        "home-or-tmp": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "source-map-support": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz"
+      },
       "dependencies": {
         "core-js": {
           "version": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
@@ -698,6 +1227,10 @@
       "version": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
       "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
       "dev": true,
+      "requires": {
+        "core-js": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+        "regenerator-runtime": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+      },
       "dependencies": {
         "core-js": {
           "version": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
@@ -709,17 +1242,41 @@
     "babel-template": {
       "version": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
       "integrity": "sha1-ZlJBFmt8KqTGGdceGSlpVSsQwHE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+        "babylon": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+      }
     },
     "babel-traverse": {
       "version": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
       "integrity": "sha1-IldJfi/NGbie3BPEyROB+VEklvE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+        "babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+        "babylon": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+        "globals": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+        "invariant": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+      }
     },
     "babel-types": {
       "version": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
       "integrity": "sha1-cK+ySNVmDl0Y+BHZHIMDtUE0oY4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+        "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+        "to-fast-properties": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+      }
     },
     "babylon": {
       "version": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz",
@@ -760,7 +1317,10 @@
       "version": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "tweetnacl": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
+      }
     },
     "beeper": {
       "version": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
@@ -770,7 +1330,10 @@
     "better-assert": {
       "version": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
       "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "callsite": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
+      }
     },
     "big.js": {
       "version": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
@@ -795,7 +1358,10 @@
     "block-stream": {
       "version": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+      }
     },
     "bluebird": {
       "version": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
@@ -815,17 +1381,35 @@
     "boom": {
       "version": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+      "dev": true,
+      "requires": {
+        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+      }
+    },
+    "bowser": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.8.0.tgz",
+      "integrity": "sha512-ARpB9VfvItCA47oBk9tVA/L93fU83Q2YwE1yTjhCyr1tu6Zw74mDHdpXNWutl5/tFGYhgCOfBH83WJY4RBGA3A==",
       "dev": true
     },
     "brace-expansion": {
       "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+        "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+      }
     },
     "braces": {
       "version": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "expand-range": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+        "preserve": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+        "repeat-element": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
+      }
     },
     "brorand": {
       "version": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
@@ -841,6 +1425,34 @@
       "version": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.18.8.tgz",
       "integrity": "sha1-L7TeJTeY18+4Oa+5wvgBloSQzsI=",
       "dev": true,
+      "requires": {
+        "browser-sync-client": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.4.5.tgz",
+        "browser-sync-ui": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-0.6.3.tgz",
+        "bs-recipes": "https://registry.npmjs.org/bs-recipes/-/bs-recipes-1.3.4.tgz",
+        "chokidar": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.1.tgz",
+        "connect": "https://registry.npmjs.org/connect/-/connect-3.5.0.tgz",
+        "dev-ip": "https://registry.npmjs.org/dev-ip/-/dev-ip-1.0.1.tgz",
+        "easy-extender": "https://registry.npmjs.org/easy-extender/-/easy-extender-2.3.2.tgz",
+        "eazy-logger": "https://registry.npmjs.org/eazy-logger/-/eazy-logger-3.0.2.tgz",
+        "emitter-steward": "https://registry.npmjs.org/emitter-steward/-/emitter-steward-1.0.0.tgz",
+        "fs-extra": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
+        "http-proxy": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.15.2.tgz",
+        "immutable": "https://registry.npmjs.org/immutable/-/immutable-3.8.1.tgz",
+        "localtunnel": "https://registry.npmjs.org/localtunnel/-/localtunnel-1.8.2.tgz",
+        "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+        "opn": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
+        "portscanner": "https://registry.npmjs.org/portscanner/-/portscanner-2.1.1.tgz",
+        "qs": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz",
+        "resp-modifier": "https://registry.npmjs.org/resp-modifier/-/resp-modifier-6.0.2.tgz",
+        "rx": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
+        "serve-index": "https://registry.npmjs.org/serve-index/-/serve-index-1.8.0.tgz",
+        "serve-static": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz",
+        "server-destroy": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
+        "socket.io": "https://registry.npmjs.org/socket.io/-/socket.io-1.6.0.tgz",
+        "socket.io-client": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.6.0.tgz",
+        "ua-parser-js": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.12.tgz",
+        "yargs": "https://registry.npmjs.org/yargs/-/yargs-6.4.0.tgz"
+      },
       "dependencies": {
         "camelcase": {
           "version": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
@@ -860,64 +1472,149 @@
         "yargs": {
           "version": "https://registry.npmjs.org/yargs/-/yargs-6.4.0.tgz",
           "integrity": "sha1-gW4ahm1VmMzzTlWW3c4i2S2kkNQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+            "cliui": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+            "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "get-caller-file": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+            "os-locale": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+            "read-pkg-up": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+            "require-directory": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "require-main-filename": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+            "set-blocking": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+            "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "which-module": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+            "window-size": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
+            "y18n": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+            "yargs-parser": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz"
+          }
         }
       }
     },
     "browser-sync-client": {
       "version": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.4.5.tgz",
       "integrity": "sha1-l2r6saVPJVuqOP4irjwNN1OtM3s=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "etag": "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz",
+        "fresh": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
+      }
     },
     "browser-sync-ui": {
       "version": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-0.6.3.tgz",
       "integrity": "sha1-ZApTfBgGiTA9W+krxHa568RBwLw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "async-each-series": "https://registry.npmjs.org/async-each-series/-/async-each-series-0.1.1.tgz",
+        "connect-history-api-fallback": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.3.0.tgz",
+        "immutable": "https://registry.npmjs.org/immutable/-/immutable-3.8.1.tgz",
+        "server-destroy": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
+        "stream-throttle": "https://registry.npmjs.org/stream-throttle/-/stream-throttle-0.1.3.tgz",
+        "weinre": "https://registry.npmjs.org/weinre/-/weinre-2.0.0-pre-I0Z7U9OV.tgz"
+      }
     },
     "browserify-aes": {
       "version": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
       "integrity": "sha1-Xncl297x/Vkw1OurSFZ85FHEigo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "buffer-xor": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+        "cipher-base": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.3.tgz",
+        "create-hash": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
+        "evp_bytestokey": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+      }
     },
     "browserify-cipher": {
       "version": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
       "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "browserify-aes": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
+        "browserify-des": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
+        "evp_bytestokey": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz"
+      }
     },
     "browserify-des": {
       "version": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
       "integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "cipher-base": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.3.tgz",
+        "des.js": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+      }
     },
     "browserify-rsa": {
       "version": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "bn.js": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.7.tgz",
+        "randombytes": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz"
+      }
     },
     "browserify-sign": {
       "version": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "bn.js": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.7.tgz",
+        "browserify-rsa": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+        "create-hash": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
+        "create-hmac": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
+        "elliptic": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "parse-asn1": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz"
+      }
     },
     "browserify-zlib": {
       "version": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
       "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pako": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz"
+      }
     },
     "browserslist": {
       "version": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
       "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "caniuse-db": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000696.tgz",
+        "electron-to-chromium": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.15.tgz"
+      }
     },
     "bs-recipes": {
       "version": "https://registry.npmjs.org/bs-recipes/-/bs-recipes-1.3.4.tgz",
       "integrity": "sha1-DS1NSKcYyMBEdp/cT4lZLci2lYU=",
       "dev": true
     },
+    "buble": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/buble/-/buble-0.15.2.tgz",
+      "integrity": "sha1-VH/EdIP45egXbYKqXrzLGDsC1hM=",
+      "dev": true,
+      "requires": {
+        "acorn": "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz",
+        "acorn-jsx": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+        "acorn-object-spread": "1.0.0",
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "magic-string": "0.14.0",
+        "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+        "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
+      }
+    },
     "buffer": {
       "version": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "base64-js": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
+        "ieee754": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+        "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+      }
     },
     "buffer-xor": {
       "version": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
@@ -927,7 +1624,10 @@
     "bufferstreams": {
       "version": "https://registry.npmjs.org/bufferstreams/-/bufferstreams-1.1.1.tgz",
       "integrity": "sha1-AWE3MGCsWYjv+ZBYcxEU9uGV1R4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz"
+      }
     },
     "builtin-modules": {
       "version": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
@@ -942,12 +1642,28 @@
     "bump-regex": {
       "version": "https://registry.npmjs.org/bump-regex/-/bump-regex-2.7.0.tgz",
       "integrity": "sha1-SiHiU3ETR2wCa+WIuKfd3vGTRkE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+        "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+      }
+    },
+    "cachedir": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-1.1.1.tgz",
+      "integrity": "sha1-4TYwdeogahJ2fZK7cRyKL3ahD2I=",
+      "dev": true,
+      "requires": {
+        "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
+      }
     },
     "caller-path": {
       "version": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "callsites": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz"
+      }
     },
     "callsite": {
       "version": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
@@ -962,7 +1678,11 @@
     "camel-case": {
       "version": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
       "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "no-case": "https://registry.npmjs.org/no-case/-/no-case-2.3.1.tgz",
+        "upper-case": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz"
+      }
     },
     "camelcase": {
       "version": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
@@ -971,12 +1691,22 @@
     "camelcase-keys": {
       "version": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+        "map-obj": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+      }
     },
     "caniuse-api": {
       "version": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz",
       "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "browserslist": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+        "caniuse-db": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000696.tgz",
+        "lodash.memoize": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+        "lodash.uniq": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz"
+      }
     },
     "caniuse-db": {
       "version": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000696.tgz",
@@ -991,12 +1721,23 @@
     "center-align": {
       "version": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "align-text": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
+      }
     },
     "chalk": {
       "version": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
+      "requires": {
+        "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+        "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+        "has-ansi": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+        "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+      },
       "dependencies": {
         "supports-color": {
           "version": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
@@ -1008,17 +1749,48 @@
     "cheerio": {
       "version": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
       "integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "css-select": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+        "dom-serializer": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+        "entities": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+        "htmlparser2": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
+        "lodash.assignin": "https://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
+        "lodash.bind": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz",
+        "lodash.defaults": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+        "lodash.filter": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
+        "lodash.flatten": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+        "lodash.foreach": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
+        "lodash.map": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
+        "lodash.merge": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
+        "lodash.pick": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+        "lodash.reduce": "https://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz",
+        "lodash.reject": "https://registry.npmjs.org/lodash.reject/-/lodash.reject-4.6.0.tgz",
+        "lodash.some": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz"
+      }
     },
     "chokidar": {
       "version": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.1.tgz",
       "integrity": "sha1-L0RHq16W5Q+z14n9kNTHLg5McMI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "anymatch": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
+        "async-each": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+        "glob-parent": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "is-binary-path": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+        "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+        "readdirp": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz"
+      }
     },
     "cipher-base": {
       "version": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.3.tgz",
       "integrity": "sha1-7qvxlEGc6QDaMBjCB9IS8qbfCgc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+      }
     },
     "circular-json": {
       "version": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
@@ -1028,12 +1800,24 @@
     "clap": {
       "version": "https://registry.npmjs.org/clap/-/clap-1.2.0.tgz",
       "integrity": "sha1-WckP4+E3EEdG/xlGmiemNP9oyFc=",
+      "dev": true,
+      "requires": {
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
+      }
+    },
+    "classnames": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz",
+      "integrity": "sha1-+zgB1FNGdknvNgPH1hoCvRKb3m0=",
       "dev": true
     },
     "clean-css": {
       "version": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.5.tgz",
       "integrity": "sha1-0JqHoCpTdRF1iXlq52oGPKzbVBo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+      }
     },
     "clean-sketch": {
       "version": "https://registry.npmjs.org/clean-sketch/-/clean-sketch-1.0.1.tgz",
@@ -1043,16 +1827,36 @@
     "cli-cursor": {
       "version": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "restore-cursor": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz"
+      }
     },
     "cli-width": {
       "version": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
       "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=",
       "dev": true
     },
+    "clipboard": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-1.7.1.tgz",
+      "integrity": "sha1-Ng1taUbpmnof7zleQrqStem1oWs=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "good-listener": "1.2.2",
+        "select": "1.1.2",
+        "tiny-emitter": "2.0.2"
+      }
+    },
     "cliui": {
       "version": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0="
+      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+      "requires": {
+        "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+        "wrap-ansi": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz"
+      }
     },
     "clone": {
       "version": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
@@ -1072,7 +1876,12 @@
     "cloneable-readable": {
       "version": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.0.0.tgz",
       "integrity": "sha1-pikNQT8hemEjL5XkWP84QYz7ARc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+      }
     },
     "co": {
       "version": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -1082,7 +1891,10 @@
     "coa": {
       "version": "https://registry.npmjs.org/coa/-/coa-1.0.3.tgz",
       "integrity": "sha1-G1Sl4dz3fJkEVdTe6pjFZEFtyJM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "q": "https://registry.npmjs.org/q/-/q-1.5.0.tgz"
+      }
     },
     "code-point-at": {
       "version": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
@@ -1091,12 +1903,20 @@
     "color": {
       "version": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
       "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "clone": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+        "color-convert": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
+        "color-string": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz"
+      }
     },
     "color-convert": {
       "version": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
       "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "color-name": "https://registry.npmjs.org/color-name/-/color-name-1.1.2.tgz"
+      }
     },
     "color-name": {
       "version": "https://registry.npmjs.org/color-name/-/color-name-1.1.2.tgz",
@@ -1106,12 +1926,20 @@
     "color-string": {
       "version": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
       "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "color-name": "https://registry.npmjs.org/color-name/-/color-name-1.1.2.tgz"
+      }
     },
     "colormin": {
       "version": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
       "integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "color": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
+        "css-color-names": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
+        "has": "https://registry.npmjs.org/has/-/has-1.0.1.tgz"
+      }
     },
     "colors": {
       "version": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
@@ -1121,17 +1949,56 @@
     "combined-stream": {
       "version": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "delayed-stream": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+      }
     },
     "commander": {
       "version": "https://registry.npmjs.org/commander/-/commander-2.10.0.tgz",
       "integrity": "sha1-4fXTJF3iRtGlygRwL6GtG9fkBf4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-readlink": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+      }
+    },
+    "commitizen": {
+      "version": "2.9.6",
+      "resolved": "https://registry.npmjs.org/commitizen/-/commitizen-2.9.6.tgz",
+      "integrity": "sha1-wNAFNe8mTaf2Nzft/aQiiYP6IpE=",
+      "dev": true,
+      "requires": {
+        "cachedir": "1.1.1",
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "cz-conventional-changelog": "1.2.0",
+        "dedent": "0.6.0",
+        "detect-indent": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+        "find-node-modules": "1.0.4",
+        "find-root": "1.0.0",
+        "fs-extra": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+        "inquirer": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+        "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+        "path-exists": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+        "shelljs": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
+        "strip-json-comments": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz"
+      }
     },
     "commondir": {
       "version": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
+    },
+    "compare-func": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.2.tgz",
+      "integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
+      "dev": true,
+      "requires": {
+        "array-ify": "1.0.0",
+        "dot-prop": "3.0.0"
+      }
     },
     "component-bind": {
       "version": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
@@ -1148,6 +2015,18 @@
       "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=",
       "dev": true
     },
+    "component-props": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/component-props/-/component-props-1.1.1.tgz",
+      "integrity": "sha1-+bffm5kntubZfJvScqqGdnDzSUQ=",
+      "dev": true
+    },
+    "component-xor": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/component-xor/-/component-xor-0.0.3.tgz",
+      "integrity": "sha1-aK5/HEC3jYQ9afKoKc+zHWr78FE=",
+      "dev": true
+    },
     "concat-map": {
       "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
@@ -1156,22 +2035,40 @@
     "concat-stream": {
       "version": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+        "typedarray": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+      }
     },
     "config-chain": {
       "version": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
       "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ini": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+        "proto-list": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
+      }
     },
     "connect": {
       "version": "https://registry.npmjs.org/connect/-/connect-3.5.0.tgz",
       "integrity": "sha1-s1dSWgtMH1BZnNmD4dnv7qlncZg=",
       "dev": true,
+      "requires": {
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+        "finalhandler": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
+        "parseurl": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+        "utils-merge": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
+      },
       "dependencies": {
         "debug": {
           "version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+          }
         },
         "ms": {
           "version": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
@@ -1188,7 +2085,10 @@
     "console-browserify": {
       "version": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "date-now": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
+      }
     },
     "console-control-strings": {
       "version": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
@@ -1198,7 +2098,10 @@
     "consolidate": {
       "version": "https://registry.npmjs.org/consolidate/-/consolidate-0.14.5.tgz",
       "integrity": "sha1-WiUEe8dvcwcmZ8jLUsmJiI9JTGM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "bluebird": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz"
+      }
     },
     "constants-browserify": {
       "version": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
@@ -1215,6 +2118,192 @@
       "integrity": "sha1-w+VpiMU8ZRJ/tG1AMqOpACRv3JQ=",
       "dev": true
     },
+    "conventional-changelog": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.6.tgz",
+      "integrity": "sha512-AaQRALJYQVbfMs0UYJ3jf5yIAJwGnm/E7ETwzZMwF/3JDMyDaa4agLQomz94pcYiGH7zcrxFcwHApSODOYnunA==",
+      "dev": true,
+      "requires": {
+        "conventional-changelog-angular": "1.5.1",
+        "conventional-changelog-atom": "0.1.1",
+        "conventional-changelog-codemirror": "0.2.0",
+        "conventional-changelog-core": "1.9.2",
+        "conventional-changelog-ember": "0.2.8",
+        "conventional-changelog-eslint": "0.2.0",
+        "conventional-changelog-express": "0.2.0",
+        "conventional-changelog-jquery": "0.1.0",
+        "conventional-changelog-jscs": "0.1.0",
+        "conventional-changelog-jshint": "0.2.0"
+      }
+    },
+    "conventional-changelog-angular": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.5.1.tgz",
+      "integrity": "sha512-AnjnPyqHp8yR2IOWsXYOCv6Ly0WC2rLRK04fgAS/5QoA3ovYLSoz9PKB5pcSG3M9lAf40IqZwU3R3G6Hy7XCSA==",
+      "dev": true,
+      "requires": {
+        "compare-func": "1.3.2",
+        "q": "https://registry.npmjs.org/q/-/q-1.5.0.tgz"
+      }
+    },
+    "conventional-changelog-atom": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-0.1.1.tgz",
+      "integrity": "sha512-6Nlu/+MiD4gi7k3Z+N1vMJWpaPSdvFPWzPGnH4OXewHAxiAl0L/TT9CGgA01fosPxmYr4hMNtD7kyN0tkg8vIA==",
+      "dev": true,
+      "requires": {
+        "q": "https://registry.npmjs.org/q/-/q-1.5.0.tgz"
+      }
+    },
+    "conventional-changelog-codemirror": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.2.0.tgz",
+      "integrity": "sha512-jUbY98JoKdAOR5k3pOBiKZ+Iz9t2F84hL7x4WjSRW6x7FdeCEUOjyfml+YClE2h/h62Tf3mwur5jSO8upxxc1g==",
+      "dev": true,
+      "requires": {
+        "q": "https://registry.npmjs.org/q/-/q-1.5.0.tgz"
+      }
+    },
+    "conventional-changelog-core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-1.9.2.tgz",
+      "integrity": "sha512-L/boGKXaKWrlCU8bHa1QM36Pb/JopCPmekj5SFqqAuBfjya860xX2fAC5Ggelse++Bw39AZ2NrHwBnJrdwLlLw==",
+      "dev": true,
+      "requires": {
+        "conventional-changelog-writer": "2.0.1",
+        "conventional-commits-parser": "2.0.0",
+        "dateformat": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
+        "get-pkg-repo": "1.4.0",
+        "git-raw-commits": "1.2.0",
+        "git-remote-origin-url": "2.0.0",
+        "git-semver-tags": "1.2.2",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+        "normalize-package-data": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+        "q": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
+        "read-pkg": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+        "read-pkg-up": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+      }
+    },
+    "conventional-changelog-ember": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-0.2.8.tgz",
+      "integrity": "sha512-smsh0o/S95n22lrQZrSHYjJrxIGoFl+OFHK+q2KGHA2zRFrW7QilYM7VUjgmB+emzwqFguPjrq+D2U8iPhMNJg==",
+      "dev": true,
+      "requires": {
+        "q": "https://registry.npmjs.org/q/-/q-1.5.0.tgz"
+      }
+    },
+    "conventional-changelog-eslint": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-0.2.0.tgz",
+      "integrity": "sha512-WGKnC0bGPD6BHGiRBfYqNGfy6DZDn2jGs1yxPRT8I2796wYdGqsbDF4477o4fdsxUJvckoW2OFPqkmRMQaCHSA==",
+      "dev": true,
+      "requires": {
+        "q": "https://registry.npmjs.org/q/-/q-1.5.0.tgz"
+      }
+    },
+    "conventional-changelog-express": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-0.2.0.tgz",
+      "integrity": "sha512-ujSEmbWfozC1iIjH5Pl7AKtREowvAl10whs1q6c7nZLnoNZK5CmdB2PQ/V42O6rCgUzaLX+ACRW2+g0A/Htqvw==",
+      "dev": true,
+      "requires": {
+        "q": "https://registry.npmjs.org/q/-/q-1.5.0.tgz"
+      }
+    },
+    "conventional-changelog-jquery": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-0.1.0.tgz",
+      "integrity": "sha1-Agg5cWLjhGmG5xJztsecW1+A9RA=",
+      "dev": true,
+      "requires": {
+        "q": "https://registry.npmjs.org/q/-/q-1.5.0.tgz"
+      }
+    },
+    "conventional-changelog-jscs": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-jscs/-/conventional-changelog-jscs-0.1.0.tgz",
+      "integrity": "sha1-BHnrRDzH1yxYvwvPDvHURKkvDlw=",
+      "dev": true,
+      "requires": {
+        "q": "https://registry.npmjs.org/q/-/q-1.5.0.tgz"
+      }
+    },
+    "conventional-changelog-jshint": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-0.2.0.tgz",
+      "integrity": "sha512-uUP4c0et6F2teapl+YY2JHFAHD401U5CkgI+P8PyU0y1zS8BdBy6EnhqgZEXhFOp9fPzUdic+Wv/9alOqw3agQ==",
+      "dev": true,
+      "requires": {
+        "compare-func": "1.3.2",
+        "q": "https://registry.npmjs.org/q/-/q-1.5.0.tgz"
+      }
+    },
+    "conventional-changelog-writer": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-2.0.1.tgz",
+      "integrity": "sha512-X4qC758celQOKw0iUPAsH5sJX6fH6N5dboFc3elXb1/SIKhsYMukhhaxWmxRdtVUSqGt9rZg8giwBQG5B2GeKg==",
+      "dev": true,
+      "requires": {
+        "compare-func": "1.3.2",
+        "conventional-commits-filter": "1.0.0",
+        "dateformat": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
+        "handlebars": "4.0.10",
+        "json-stringify-safe": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+        "meow": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+        "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+        "split": "1.0.1",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+      }
+    },
+    "conventional-commit-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/conventional-commit-types/-/conventional-commit-types-2.2.0.tgz",
+      "integrity": "sha1-XblXOdbCEqy+e29lahG5QLqmiUY=",
+      "dev": true
+    },
+    "conventional-commits-filter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-1.0.0.tgz",
+      "integrity": "sha1-b8KmWTcrw/IznPn//34bA0S5MDk=",
+      "dev": true,
+      "requires": {
+        "is-subset": "0.1.1",
+        "modify-values": "1.0.0"
+      }
+    },
+    "conventional-commits-parser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.0.0.tgz",
+      "integrity": "sha512-8od6g684Fhi5Vpp4ABRv/RBsW1AY6wSHbJHEK6FGTv+8jvAAnlABniZu/FVmX9TcirkHepaEsa1QGkRvbg0CKw==",
+      "dev": true,
+      "requires": {
+        "is-text-path": "1.0.1",
+        "JSONStream": "1.3.1",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+        "meow": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+        "split2": "2.2.0",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+        "trim-off-newlines": "1.0.1"
+      }
+    },
+    "conventional-recommended-bump": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-1.0.2.tgz",
+      "integrity": "sha512-kC4EvXsc+flKpmD0Aa98qVGG7qGqLsVswVT0ijicXiNPBkGQAOMPYg+JoFjBXAWYWw4Y6RsiEDL+JKLrp0RqXQ==",
+      "dev": true,
+      "requires": {
+        "concat-stream": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+        "conventional-commits-filter": "1.0.0",
+        "conventional-commits-parser": "2.0.0",
+        "git-raw-commits": "1.2.0",
+        "git-semver-tags": "1.2.2",
+        "meow": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+      }
+    },
     "convert-source-map": {
       "version": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
       "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU=",
@@ -1229,6 +2318,17 @@
       "version": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
       "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
     },
+    "core-js-builder": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/core-js-builder/-/core-js-builder-2.5.1.tgz",
+      "integrity": "sha1-Eb18+q1AWQG9ayw88A1fOaOve30=",
+      "dev": true,
+      "requires": {
+        "core-js": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+        "temp": "0.8.3",
+        "webpack": "https://registry.npmjs.org/webpack/-/webpack-2.3.3.tgz"
+      }
+    },
     "core-util-is": {
       "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
@@ -1238,6 +2338,15 @@
       "version": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.1.3.tgz",
       "integrity": "sha1-lSdx6w3dwcs/ovb75RpSLpOz7go=",
       "dev": true,
+      "requires": {
+        "is-directory": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+        "js-yaml": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
+        "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+        "parse-json": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+        "require-from-string": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz"
+      },
       "dependencies": {
         "minimist": {
           "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
@@ -1249,74 +2358,165 @@
     "create-ecdh": {
       "version": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
       "integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "bn.js": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.7.tgz",
+        "elliptic": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz"
+      }
     },
     "create-hash": {
       "version": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
       "integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "cipher-base": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.3.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "ripemd160": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
+        "sha.js": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz"
+      }
     },
     "create-hmac": {
       "version": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
       "integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "cipher-base": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.3.tgz",
+        "create-hash": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "ripemd160": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
+        "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+        "sha.js": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz"
+      }
     },
     "create-react-class": {
       "version": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.0.tgz",
       "integrity": "sha1-q0SEl8JlZuHilBPogyB9V8/nvtQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fbjs": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz",
+        "loose-envify": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+      }
     },
     "cross-env": {
       "version": "https://registry.npmjs.org/cross-env/-/cross-env-5.0.0.tgz",
       "integrity": "sha1-VlzK5NCWdkQaUIf0Bv52YaKckxs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "cross-spawn": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+        "is-windows": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.1.tgz"
+      }
     },
     "cross-spawn": {
       "version": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lru-cache": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+        "shebang-command": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+        "which": "https://registry.npmjs.org/which/-/which-1.2.14.tgz"
+      }
     },
     "cryptiles": {
       "version": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+      }
     },
     "crypto-browserify": {
       "version": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.0.tgz",
       "integrity": "sha1-NlKgkGq5sqfgw85mpAjpV6JIVSI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "browserify-cipher": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
+        "browserify-sign": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
+        "create-ecdh": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
+        "create-hash": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
+        "create-hmac": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
+        "diffie-hellman": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "pbkdf2": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.12.tgz",
+        "public-encrypt": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
+        "randombytes": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz"
+      }
     },
     "css-color-names": {
       "version": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
       "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
       "dev": true
     },
+    "css-in-js-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-2.0.0.tgz",
+      "integrity": "sha512-yuWmPMD9FLi50Xf3k8W8oO3WM1eVnxEGCldCLyfusQ+CgivFk0s23yst4ooW6tfxMuSa03S6uUEga9UhX6GRrA==",
+      "dev": true,
+      "requires": {
+        "hyphenate-style-name": "1.0.2"
+      }
+    },
     "css-loader": {
       "version": "https://registry.npmjs.org/css-loader/-/css-loader-0.28.0.tgz",
       "integrity": "sha1-QXz6l4n4zeWaMMy/Pk2nqAaIm60=",
       "dev": true,
+      "requires": {
+        "babel-code-frame": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+        "css-selector-tokenizer": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
+        "cssnano": "https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
+        "loader-utils": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+        "lodash.camelcase": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz",
+        "postcss-modules-extract-imports": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.1.0.tgz",
+        "postcss-modules-local-by-default": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
+        "postcss-modules-scope": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
+        "postcss-modules-values": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
+        "source-list-map": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.8.tgz"
+      },
       "dependencies": {
         "loader-utils": {
           "version": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "big.js": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
+            "emojis-list": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+            "json5": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
+          }
         }
       }
     },
     "css-select": {
       "version": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
       "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "boolbase": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+        "css-what": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
+        "domutils": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+        "nth-check": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz"
+      }
     },
     "css-selector-tokenizer": {
       "version": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
       "integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
       "dev": true,
+      "requires": {
+        "cssesc": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
+        "fastparse": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
+        "regexpu-core": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz"
+      },
       "dependencies": {
         "regexpu-core": {
           "version": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
           "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "regenerate": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
+            "regjsgen": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+            "regjsparser": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz"
+          }
         }
       }
     },
@@ -1333,12 +2533,50 @@
     "cssnano": {
       "version": "https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
       "integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "autoprefixer": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
+        "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+        "defined": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+        "has": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz",
+        "postcss-calc": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
+        "postcss-colormin": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
+        "postcss-convert-values": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz",
+        "postcss-discard-comments": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
+        "postcss-discard-duplicates": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz",
+        "postcss-discard-empty": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
+        "postcss-discard-overridden": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
+        "postcss-discard-unused": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
+        "postcss-filter-plugins": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz",
+        "postcss-merge-idents": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
+        "postcss-merge-longhand": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz",
+        "postcss-merge-rules": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
+        "postcss-minify-font-values": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
+        "postcss-minify-gradients": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
+        "postcss-minify-params": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
+        "postcss-minify-selectors": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
+        "postcss-normalize-charset": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
+        "postcss-normalize-url": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
+        "postcss-ordered-values": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz",
+        "postcss-reduce-idents": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
+        "postcss-reduce-initial": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
+        "postcss-reduce-transforms": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
+        "postcss-svgo": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
+        "postcss-unique-selectors": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
+        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
+        "postcss-zindex": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz"
+      }
     },
     "csso": {
       "version": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
       "integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "clap": "https://registry.npmjs.org/clap/-/clap-1.2.0.tgz",
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+      }
     },
     "cssom": {
       "version": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
@@ -1348,7 +2586,10 @@
     "cssstyle": {
       "version": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
       "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "cssom": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz"
+      }
     },
     "cubic2quad": {
       "version": "https://registry.npmjs.org/cubic2quad/-/cubic2quad-1.1.1.tgz",
@@ -1358,22 +2599,54 @@
     "currently-unhandled": {
       "version": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-find-index": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz"
+      }
+    },
+    "cz-conventional-changelog": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-1.2.0.tgz",
+      "integrity": "sha1-K8oElkyJGbI/P9aonvXmAIsxs/g=",
+      "dev": true,
+      "requires": {
+        "conventional-commit-types": "2.2.0",
+        "lodash.map": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
+        "longest": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+        "pad-right": "0.2.2",
+        "right-pad": "1.0.1",
+        "word-wrap": "1.2.3"
+      }
     },
     "d": {
       "version": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.23.tgz"
+      }
     },
     "damerau-levenshtein": {
       "version": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.4.tgz",
       "integrity": "sha1-AxkcQyy27qFou3fzpV/9zLiXhRQ=",
       "dev": true
     },
+    "dargs": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/dargs/-/dargs-4.1.0.tgz",
+      "integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+      }
+    },
     "dashdash": {
       "version": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
+      "requires": {
+        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -1395,11 +2668,32 @@
     "debug": {
       "version": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
       "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ms": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+      }
     },
     "decamelize": {
       "version": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+    },
+    "decimal.js": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-7.3.0.tgz",
+      "integrity": "sha512-VVahlspSseBpHAPbf9ofz4iSJNIpaPIzrNUnY3NUoNkQQ3+0/Uh8+Jndz8gzRwOXWKwvbS556lcjqucj8f3hMw==",
+      "dev": true
+    },
+    "dedent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.6.0.tgz",
+      "integrity": "sha1-Dm2o8M5Sg471zsXI+TlrDBtko8s=",
+      "dev": true
+    },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+      "dev": true
     },
     "deep-is": {
       "version": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -1414,12 +2708,19 @@
     "defaults": {
       "version": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "clone": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+      }
     },
     "define-properties": {
       "version": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "foreach": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+        "object-keys": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz"
+      }
     },
     "defined": {
       "version": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
@@ -1429,12 +2730,28 @@
     "del": {
       "version": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "globby": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+        "is-path-cwd": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+        "is-path-in-cwd": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz"
+      }
     },
     "delayed-stream": {
       "version": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
+    },
+    "delegate": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.1.3.tgz",
+      "integrity": "sha1-moJRp3fXAl+qVXN7w7BxdCEnqf0=",
+      "dev": true,
+      "optional": true
     },
     "delegates": {
       "version": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
@@ -1454,7 +2771,11 @@
     "des.js": {
       "version": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
       "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "minimalistic-assert": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
+      }
     },
     "destroy": {
       "version": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
@@ -1464,12 +2785,18 @@
     "detect-file": {
       "version": "https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz",
       "integrity": "sha1-STXe39lIhkjgBrASlWbpOGcR6mM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fs-exists-sync": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz"
+      }
     },
     "detect-indent": {
       "version": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "repeating": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz"
+      }
     },
     "dev-ip": {
       "version": "https://registry.npmjs.org/dev-ip/-/dev-ip-1.0.1.tgz",
@@ -1484,17 +2811,29 @@
     "diffie-hellman": {
       "version": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
       "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "bn.js": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.7.tgz",
+        "miller-rabin": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz",
+        "randombytes": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz"
+      }
     },
     "doctrine": {
       "version": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
       "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+        "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+      }
     },
     "dom-converter": {
       "version": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.1.4.tgz",
       "integrity": "sha1-pF71cnuJDJv/5tfIduexnLDhfzs=",
       "dev": true,
+      "requires": {
+        "utila": "https://registry.npmjs.org/utila/-/utila-0.3.3.tgz"
+      },
       "dependencies": {
         "utila": {
           "version": "https://registry.npmjs.org/utila/-/utila-0.3.3.tgz",
@@ -1503,10 +2842,24 @@
         }
       }
     },
+    "dom-iterator": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/dom-iterator/-/dom-iterator-0.3.0.tgz",
+      "integrity": "sha1-WnRb9HvGkqwPo8DDhTlv8svVWII=",
+      "dev": true,
+      "requires": {
+        "component-props": "1.1.1",
+        "component-xor": "0.0.3"
+      }
+    },
     "dom-serializer": {
       "version": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "dev": true,
+      "requires": {
+        "domelementtype": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+        "entities": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
+      },
       "dependencies": {
         "domelementtype": {
           "version": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
@@ -1528,17 +2881,36 @@
     "domhandler": {
       "version": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz",
       "integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "domelementtype": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
+      }
     },
     "domutils": {
       "version": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "dom-serializer": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+        "domelementtype": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
+      }
+    },
+    "dot-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
+      "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
+      "dev": true,
+      "requires": {
+        "is-obj": "1.0.1"
+      }
     },
     "duplexer2": {
       "version": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
       "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
       "dev": true,
+      "requires": {
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
+      },
       "dependencies": {
         "isarray": {
           "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -1548,7 +2920,13 @@
         "readable-stream": {
           "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+          }
         },
         "string_decoder": {
           "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
@@ -1561,16 +2939,28 @@
       "version": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz",
       "integrity": "sha1-GqdzAC4VeEV+nZ1KULDMquvL1gQ=",
       "dev": true,
+      "requires": {
+        "end-of-stream": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+        "stream-shift": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz"
+      },
       "dependencies": {
         "end-of-stream": {
           "version": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
           "integrity": "sha1-1FlucCc0qT5A6a+GQxnqvZn/Lw4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
+          }
         },
         "once": {
           "version": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
           "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+          }
         }
       }
     },
@@ -1578,6 +2968,9 @@
       "version": "https://registry.npmjs.org/easy-extender/-/easy-extender-2.3.2.tgz",
       "integrity": "sha1-PTJI/r4rFZYHMW2PnPSRwWZIIh0=",
       "dev": true,
+      "requires": {
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+      },
       "dependencies": {
         "lodash": {
           "version": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
@@ -1589,13 +2982,19 @@
     "eazy-logger": {
       "version": "https://registry.npmjs.org/eazy-logger/-/eazy-logger-3.0.2.tgz",
       "integrity": "sha1-oyWqXlPROiIliJsqxBE7K5Y29Pw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "tfunk": "https://registry.npmjs.org/tfunk/-/tfunk-3.1.0.tgz"
+      }
     },
     "ecc-jsbn": {
       "version": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
+      }
     },
     "ee-first": {
       "version": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -1610,7 +3009,16 @@
     "elliptic": {
       "version": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
       "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "bn.js": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.7.tgz",
+        "brorand": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+        "hash.js": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.2.tgz",
+        "hmac-drbg": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "minimalistic-assert": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+        "minimalistic-crypto-utils": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz"
+      }
     },
     "emitter-steward": {
       "version": "https://registry.npmjs.org/emitter-steward/-/emitter-steward-1.0.0.tgz",
@@ -1634,17 +3042,26 @@
     },
     "encoding": {
       "version": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s="
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "requires": {
+        "iconv-lite": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz"
+      }
     },
     "end-of-stream": {
       "version": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
       "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
       "dev": true,
+      "requires": {
+        "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
+      },
       "dependencies": {
         "once": {
           "version": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
           "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+          }
         }
       }
     },
@@ -1652,11 +3069,22 @@
       "version": "https://registry.npmjs.org/engine.io/-/engine.io-1.8.0.tgz",
       "integrity": "sha1-PutfJky3XbvsG6rqJtYfWk6s4qo=",
       "dev": true,
+      "requires": {
+        "accepts": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+        "base64id": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz",
+        "cookie": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+        "engine.io-parser": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.1.tgz",
+        "ws": "https://registry.npmjs.org/ws/-/ws-1.1.1.tgz"
+      },
       "dependencies": {
         "debug": {
           "version": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
           "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+          }
         },
         "ms": {
           "version": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
@@ -1669,6 +3097,20 @@
       "version": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.8.0.tgz",
       "integrity": "sha1-e3MOQSdBQIdZbZvjyI0rxf22z1w=",
       "dev": true,
+      "requires": {
+        "component-emitter": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+        "component-inherit": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+        "engine.io-parser": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.1.tgz",
+        "has-cors": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
+        "indexof": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+        "parsejson": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.3.tgz",
+        "parseqs": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
+        "parseuri": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
+        "ws": "https://registry.npmjs.org/ws/-/ws-1.1.1.tgz",
+        "xmlhttprequest-ssl": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.3.tgz",
+        "yeast": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz"
+      },
       "dependencies": {
         "component-emitter": {
           "version": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
@@ -1678,7 +3120,10 @@
         "debug": {
           "version": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
           "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+          }
         },
         "ms": {
           "version": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
@@ -1691,11 +3136,22 @@
       "version": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.1.tgz",
       "integrity": "sha1-lVTxrjMQfW+9FwylRm0vgz9qB88=",
       "dev": true,
+      "requires": {
+        "after": "https://registry.npmjs.org/after/-/after-0.8.1.tgz",
+        "arraybuffer.slice": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
+        "base64-arraybuffer": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
+        "blob": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
+        "has-binary": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
+        "wtf-8": "https://registry.npmjs.org/wtf-8/-/wtf-8-1.0.0.tgz"
+      },
       "dependencies": {
         "has-binary": {
           "version": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
           "integrity": "sha1-JTJvOc+k9hath4eJTjryz7x7bhA=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+          }
         },
         "isarray": {
           "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -1707,7 +3163,13 @@
     "enhanced-resolve": {
       "version": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.1.0.tgz",
       "integrity": "sha1-n0tib1dyRe3PSyrYPYbhf09CHew=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "memory-fs": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "tapable": "https://registry.npmjs.org/tapable/-/tapable-0.2.6.tgz"
+      }
     },
     "entities": {
       "version": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
@@ -1717,37 +3179,71 @@
     "errno": {
       "version": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
       "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "prr": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
+      }
     },
     "error-ex": {
       "version": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-arrayish": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
+      }
     },
     "es-abstract": {
       "version": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.7.0.tgz",
       "integrity": "sha1-363ndOAb/Nl/lhgCmMRJyGI/uUw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+        "function-bind": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
+        "is-callable": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+        "is-regex": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz"
+      }
     },
     "es-to-primitive": {
       "version": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-callable": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+        "is-date-object": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+        "is-symbol": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz"
+      }
     },
     "es5-ext": {
       "version": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.23.tgz",
       "integrity": "sha1-dXi1G+l0IHpUh4IbVlOMIk5Oezg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "es6-iterator": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+        "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz"
+      }
     },
     "es6-iterator": {
       "version": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
       "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.23.tgz",
+        "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz"
+      }
     },
     "es6-map": {
       "version": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.23.tgz",
+        "es6-iterator": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+        "es6-set": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+        "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+        "event-emitter": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz"
+      }
     },
     "es6-promise": {
       "version": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.0.tgz",
@@ -1757,17 +3253,34 @@
     "es6-set": {
       "version": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.23.tgz",
+        "es6-iterator": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+        "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+        "event-emitter": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz"
+      }
     },
     "es6-symbol": {
       "version": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.23.tgz"
+      }
     },
     "es6-weak-map": {
       "version": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.23.tgz",
+        "es6-iterator": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+        "es6-symbol": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz"
+      }
     },
     "escape-html": {
       "version": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -1783,6 +3296,13 @@
       "version": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
       "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
       "dev": true,
+      "requires": {
+        "esprima": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+        "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+        "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+        "optionator": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz"
+      },
       "dependencies": {
         "estraverse": {
           "version": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
@@ -1793,19 +3313,65 @@
           "version": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
           "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+          }
         }
       }
     },
     "escope": {
       "version": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "es6-map": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+        "es6-weak-map": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+        "esrecurse": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
+        "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz"
+      }
     },
     "eslint": {
       "version": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
       "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
       "dev": true,
+      "requires": {
+        "babel-code-frame": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "concat-stream": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+        "doctrine": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
+        "escope": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+        "espree": "https://registry.npmjs.org/espree/-/espree-3.4.3.tgz",
+        "esquery": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
+        "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+        "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+        "file-entry-cache": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+        "globals": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+        "ignore": "https://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz",
+        "imurmurhash": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+        "inquirer": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+        "is-my-json-valid": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
+        "is-resolvable": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
+        "js-yaml": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
+        "json-stable-stringify": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+        "levn": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "natural-compare": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+        "optionator": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+        "path-is-inside": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+        "pluralize": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
+        "progress": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+        "require-uncached": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+        "shelljs": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
+        "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+        "strip-json-comments": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+        "table": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
+        "text-table": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+        "user-home": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz"
+      },
       "dependencies": {
         "strip-bom": {
           "version": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -1832,56 +3398,115 @@
     "eslint-config-standard-react": {
       "version": "https://registry.npmjs.org/eslint-config-standard-react/-/eslint-config-standard-react-4.3.0.tgz",
       "integrity": "sha1-fg01dfFaPAtmOcy2OUnftbo6Coo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "eslint-config-standard-jsx": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-3.3.0.tgz"
+      }
     },
     "eslint-import-resolver-node": {
       "version": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.2.3.tgz",
       "integrity": "sha1-Wt2BBujJKNssuiMrzZ76hG49oWw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz"
+      }
     },
     "eslint-loader": {
       "version": "https://registry.npmjs.org/eslint-loader/-/eslint-loader-1.7.1.tgz",
       "integrity": "sha1-ULFY3WJy3O+5fphCVIN/gaWALOA=",
       "dev": true,
+      "requires": {
+        "find-cache-dir": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
+        "loader-fs-cache": "https://registry.npmjs.org/loader-fs-cache/-/loader-fs-cache-1.0.1.tgz",
+        "loader-utils": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "object-hash": "https://registry.npmjs.org/object-hash/-/object-hash-1.1.8.tgz",
+        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz"
+      },
       "dependencies": {
         "loader-utils": {
           "version": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "big.js": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
+            "emojis-list": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+            "json5": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
+          }
         }
       }
     },
     "eslint-module-utils": {
       "version": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz",
       "integrity": "sha1-q67IJBd2E7ipWymWOeG2+s9HNEk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+        "pkg-dir": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz"
+      }
     },
     "eslint-plugin-import": {
       "version": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.2.0.tgz",
       "integrity": "sha1-crowb60wXWfEgWNIpGmaQimsi04=",
       "dev": true,
+      "requires": {
+        "builtin-modules": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+        "contains-path": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+        "doctrine": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+        "eslint-import-resolver-node": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.2.3.tgz",
+        "eslint-module-utils": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz",
+        "has": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+        "lodash.cond": "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
+        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+        "pkg-up": "https://registry.npmjs.org/pkg-up/-/pkg-up-1.0.0.tgz"
+      },
       "dependencies": {
         "doctrine": {
           "version": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+          }
         }
       }
     },
     "eslint-plugin-jsx-a11y": {
       "version": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-4.0.0.tgz",
       "integrity": "sha1-d5uw/nsI2lZKQiYkkR3hAGHgSO4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "aria-query": "https://registry.npmjs.org/aria-query/-/aria-query-0.3.0.tgz",
+        "ast-types-flow": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
+        "damerau-levenshtein": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.4.tgz",
+        "emoji-regex": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.4.2.tgz",
+        "jsx-ast-utils": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+      }
     },
     "eslint-plugin-mocha": {
       "version": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-4.9.0.tgz",
       "integrity": "sha1-kXqLSZq40MAdacbk+B02LuCZtv0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ramda": "https://registry.npmjs.org/ramda/-/ramda-0.23.0.tgz"
+      }
     },
     "eslint-plugin-node": {
       "version": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-4.2.2.tgz",
       "integrity": "sha1-gpWcqa7Xn8vSi7GxiNBcrAT7M2M=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ignore": "https://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz",
+        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+        "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
+      }
     },
     "eslint-plugin-promise": {
       "version": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-3.5.0.tgz",
@@ -1892,11 +3517,22 @@
       "version": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-6.10.3.tgz",
       "integrity": "sha1-xUNb6wZ3ThLH2y9qut3L+QDNP3g=",
       "dev": true,
+      "requires": {
+        "array.prototype.find": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.0.4.tgz",
+        "doctrine": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+        "has": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+        "jsx-ast-utils": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz",
+        "object.assign": "https://registry.npmjs.org/object.assign/-/object.assign-4.0.4.tgz"
+      },
       "dependencies": {
         "doctrine": {
           "version": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+          }
         }
       }
     },
@@ -1908,7 +3544,11 @@
     "espree": {
       "version": "https://registry.npmjs.org/espree/-/espree-3.4.3.tgz",
       "integrity": "sha1-KRC1zNSc6JPC//+qtP2LOjG4I3Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "acorn": "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz",
+        "acorn-jsx": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz"
+      }
     },
     "esprima": {
       "version": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
@@ -1918,12 +3558,19 @@
     "esquery": {
       "version": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
       "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz"
+      }
     },
     "esrecurse": {
       "version": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
       "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+      }
     },
     "estraverse": {
       "version": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
@@ -1943,7 +3590,11 @@
     "event-emitter": {
       "version": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+        "es5-ext": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.23.tgz"
+      }
     },
     "eventemitter3": {
       "version": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
@@ -1958,7 +3609,10 @@
     "evp_bytestokey": {
       "version": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz",
       "integrity": "sha1-SXtmrZ/vZc18CKYYCCS6FHa2blM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "create-hash": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz"
+      }
     },
     "exit-hook": {
       "version": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
@@ -1968,27 +3622,47 @@
     "expand-brackets": {
       "version": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-posix-bracket": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
+      }
     },
     "expand-range": {
       "version": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fill-range": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz"
+      }
     },
     "expand-tilde": {
       "version": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
       "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
+      }
     },
     "express": {
       "version": "https://registry.npmjs.org/express/-/express-2.5.11.tgz",
       "integrity": "sha1-TOjqHzY15p5J8Ou0l7aksKUc5vA=",
       "dev": true,
+      "requires": {
+        "connect": "https://registry.npmjs.org/connect/-/connect-1.9.2.tgz",
+        "mime": "https://registry.npmjs.org/mime/-/mime-1.2.4.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+        "qs": "https://registry.npmjs.org/qs/-/qs-0.4.2.tgz"
+      },
       "dependencies": {
         "connect": {
           "version": "https://registry.npmjs.org/connect/-/connect-1.9.2.tgz",
           "integrity": "sha1-QogKIulDiuWait105Df1iujlKAc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "formidable": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz",
+            "mime": "https://registry.npmjs.org/mime/-/mime-1.2.4.tgz",
+            "qs": "https://registry.npmjs.org/qs/-/qs-0.4.2.tgz"
+          }
         },
         "mkdirp": {
           "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
@@ -2011,6 +3685,9 @@
       "version": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
       "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
       "dev": true,
+      "requires": {
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz"
+      },
       "dependencies": {
         "kind-of": {
           "version": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
@@ -2022,22 +3699,39 @@
     "extglob": {
       "version": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+      }
     },
     "extract-text-webpack-plugin": {
       "version": "https://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-2.1.0.tgz",
       "integrity": "sha1-aTFbiF+Hbb+W04Gfap8cynrr8Vk=",
       "dev": true,
+      "requires": {
+        "ajv": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+        "async": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
+        "loader-utils": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+        "webpack-sources": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.1.5.tgz"
+      },
       "dependencies": {
         "async": {
           "version": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
           "integrity": "sha1-hDGQ/WtzV6C54clW7d3V7IRitU0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+          }
         },
         "loader-utils": {
           "version": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "big.js": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
+            "emojis-list": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+            "json5": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
+          }
         }
       }
     },
@@ -2049,7 +3743,11 @@
     "fancy-log": {
       "version": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
       "integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "time-stamp": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz"
+      }
     },
     "fast-levenshtein": {
       "version": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
@@ -2063,17 +3761,43 @@
     },
     "fbjs": {
       "version": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz",
-      "integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ="
+      "integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ=",
+      "requires": {
+        "core-js": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+        "isomorphic-fetch": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+        "loose-envify": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "promise": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+        "setimmediate": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+        "ua-parser-js": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.13.tgz"
+      }
     },
     "figures": {
       "version": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+      }
     },
     "file-entry-cache": {
       "version": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "flat-cache": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+      }
+    },
+    "file-loader": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-0.11.2.tgz",
+      "integrity": "sha512-N+uhF3mswIFeziHQjGScJ/yHXYt3DiLBeC+9vWW+WjUBiClMSOlV1YrXQi+7KM2aA3Rn4Bybgv+uXFQbfkzpvg==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz"
+      }
     },
     "filename-regex": {
       "version": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
@@ -2083,17 +3807,34 @@
     "fill-range": {
       "version": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-number": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+        "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+        "randomatic": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+        "repeat-element": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+        "repeat-string": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+      }
     },
     "finalhandler": {
       "version": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
       "integrity": "sha1-6VCKvs6bbbqHGmlCodeRG5GRGsc=",
       "dev": true,
+      "requires": {
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+        "escape-html": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+        "on-finished": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+        "statuses": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+        "unpipe": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
+      },
       "dependencies": {
         "debug": {
           "version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+          }
         },
         "ms": {
           "version": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
@@ -2105,32 +3846,73 @@
     "find-cache-dir": {
       "version": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
       "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "commondir": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "pkg-dir": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz"
+      }
     },
     "find-index": {
       "version": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
       "integrity": "sha1-Z101iyyjiS15Whq0cjL4tuLg3eQ=",
       "dev": true
     },
+    "find-node-modules": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/find-node-modules/-/find-node-modules-1.0.4.tgz",
+      "integrity": "sha1-tt6zzMtpnIcDdne87eLF9YYrJVA=",
+      "dev": true,
+      "requires": {
+        "findup-sync": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.3.tgz",
+        "merge": "1.2.0"
+      }
+    },
+    "find-root": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.0.0.tgz",
+      "integrity": "sha1-li/yEaqyXGUg/u641ih/j26VgHo=",
+      "dev": true
+    },
     "find-up": {
       "version": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "path-exists": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+      }
     },
     "findup-sync": {
       "version": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.3.tgz",
       "integrity": "sha1-QAQ5Kee8YK3wt/SCfExudaDeyhI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "detect-file": "https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz",
+        "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+        "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+        "resolve-dir": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz"
+      }
     },
     "fined": {
       "version": "https://registry.npmjs.org/fined/-/fined-1.1.0.tgz",
       "integrity": "sha1-s33IRLdqL15wgeiE98CuNE8VNHY=",
       "dev": true,
+      "requires": {
+        "expand-tilde": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+        "is-plain-object": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.3.tgz",
+        "object.defaults": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
+        "object.pick": "https://registry.npmjs.org/object.pick/-/object.pick-1.2.0.tgz",
+        "parse-filepath": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.1.tgz"
+      },
       "dependencies": {
         "expand-tilde": {
           "version": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
           "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "homedir-polyfill": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz"
+          }
         }
       }
     },
@@ -2147,17 +3929,32 @@
     "flat-cache": {
       "version": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
       "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "circular-json": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
+        "del": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "write": "https://registry.npmjs.org/write/-/write-0.2.1.tgz"
+      }
     },
     "flatten": {
       "version": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
       "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=",
       "dev": true
     },
+    "flow-parser": {
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.56.0.tgz",
+      "integrity": "sha1-jvHDJfUAAEk8p2TD7N0PLHGpxSU=",
+      "dev": true
+    },
     "follow-redirects": {
       "version": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.2.4.tgz",
       "integrity": "sha1-NV6PTRaHa0P1d7DVziZouXIyFOo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz"
+      }
     },
     "for-in": {
       "version": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -2167,7 +3964,10 @@
     "for-own": {
       "version": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "for-in": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz"
+      }
     },
     "foreach": {
       "version": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
@@ -2182,7 +3982,12 @@
     "form-data": {
       "version": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
       "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "asynckit": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+        "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz"
+      }
     },
     "formidable": {
       "version": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz",
@@ -2194,6 +3999,15 @@
       "integrity": "sha1-ZR+DjiJCTnVm3hYdg1jKoZn4PU8=",
       "dev": true
     },
+    "fs-access": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
+      "integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
+      "dev": true,
+      "requires": {
+        "null-check": "1.0.0"
+      }
+    },
     "fs-exists-sync": {
       "version": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
       "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=",
@@ -2202,786 +4016,28 @@
     "fs-extra": {
       "version": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
       "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "jsonfile": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+        "klaw": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz"
+      }
     },
     "fs.realpath": {
       "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
-    "fsevents": {
-      "version": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
-      "integrity": "sha1-MoK3E/s62A7eDp/PRhG1qm/AM/Q=",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "abbrev": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
-          "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
-          "dev": true,
-          "optional": true
-        },
-        "ajv": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-          "dev": true,
-          "optional": true
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "aproba": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
-          "integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s=",
-          "dev": true,
-          "optional": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
-          "dev": true,
-          "optional": true
-        },
-        "asn1": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-          "dev": true,
-          "optional": true
-        },
-        "assert-plus": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-          "dev": true,
-          "optional": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-          "dev": true,
-          "optional": true
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-          "dev": true,
-          "optional": true
-        },
-        "aws4": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-          "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
-          "dev": true,
-          "optional": true
-        },
-        "balanced-match": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
-          "dev": true
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-          "dev": true,
-          "optional": true
-        },
-        "block-stream": {
-          "version": "0.0.9",
-          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-          "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-          "dev": true
-        },
-        "boom": {
-          "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-          "dev": true
-        },
-        "brace-expansion": {
-          "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
-          "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
-          "dev": true
-        },
-        "buffer-shims": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-          "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
-          "dev": true
-        },
-        "caseless": {
-          "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-          "dev": true,
-          "optional": true
-        },
-        "co": {
-          "version": "4.6.0",
-          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-          "dev": true,
-          "optional": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-          "dev": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-          "dev": true
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-          "dev": true,
-          "optional": true
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-          "dev": true,
-          "optional": true,
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-          "dev": true,
-          "optional": true
-        },
-        "deep-extend": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
-          "dev": true,
-          "optional": true
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-          "dev": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-          "dev": true,
-          "optional": true
-        },
-        "ecc-jsbn": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-          "dev": true,
-          "optional": true
-        },
-        "extend": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
-          "dev": true,
-          "optional": true
-        },
-        "extsprintf": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
-          "dev": true
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-          "dev": true,
-          "optional": true
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-          "dev": true,
-          "optional": true
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-          "dev": true
-        },
-        "fstream": {
-          "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-          "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-          "dev": true
-        },
-        "fstream-ignore": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-          "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
-          "dev": true,
-          "optional": true
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-          "dev": true,
-          "optional": true
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-          "dev": true,
-          "optional": true,
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true
-        },
-        "har-schema": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-          "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
-          "dev": true,
-          "optional": true
-        },
-        "har-validator": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-          "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-          "dev": true,
-          "optional": true
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-          "dev": true,
-          "optional": true
-        },
-        "hawk": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-          "dev": true,
-          "optional": true
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-          "dev": true
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-          "dev": true,
-          "optional": true
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-          "dev": true
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
-        },
-        "ini": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
-          "dev": true,
-          "optional": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-          "dev": true,
-          "optional": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-          "dev": true,
-          "optional": true
-        },
-        "jodid25519": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-          "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
-          "dev": true,
-          "optional": true
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-          "dev": true,
-          "optional": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-          "dev": true,
-          "optional": true
-        },
-        "json-stable-stringify": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-          "dev": true,
-          "optional": true
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-          "dev": true,
-          "optional": true
-        },
-        "jsonify": {
-          "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-          "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-          "dev": true,
-          "optional": true
-        },
-        "jsprim": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-          "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
-          "dev": true,
-          "optional": true,
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "mime-db": {
-          "version": "1.27.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
-          "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
-          "dev": true
-        },
-        "mime-types": {
-          "version": "2.1.15",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-          "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "dev": true
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true,
-          "optional": true
-        },
-        "node-pre-gyp": {
-          "version": "0.6.36",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz",
-          "integrity": "sha1-22BBEst04NR3VU6bUFsXq936t4Y=",
-          "dev": true,
-          "optional": true
-        },
-        "nopt": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
-          "dev": true,
-          "optional": true
-        },
-        "npmlog": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
-          "integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
-          "dev": true,
-          "optional": true
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-          "dev": true,
-          "optional": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true,
-          "optional": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "dev": true
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-          "dev": true,
-          "optional": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-          "dev": true,
-          "optional": true
-        },
-        "osenv": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-          "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
-          "dev": true,
-          "optional": true
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-          "dev": true
-        },
-        "performance-now": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
-          "dev": true,
-          "optional": true
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-          "dev": true
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-          "dev": true,
-          "optional": true
-        },
-        "qs": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
-          "dev": true,
-          "optional": true
-        },
-        "rc": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-          "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
-          "dev": true,
-          "optional": true,
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.2.9",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-          "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
-          "dev": true
-        },
-        "request": {
-          "version": "2.81.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-          "dev": true,
-          "optional": true
-        },
-        "rimraf": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-          "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-          "dev": true
-        },
-        "safe-buffer": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-          "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
-          "dev": true
-        },
-        "semver": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-          "dev": true,
-          "optional": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-          "dev": true,
-          "optional": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-          "dev": true,
-          "optional": true
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-          "dev": true,
-          "optional": true
-        },
-        "sshpk": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
-          "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
-          "dev": true,
-          "optional": true,
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-          "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-          "dev": true,
-          "optional": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-          "dev": true,
-          "optional": true
-        },
-        "tar": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-          "dev": true
-        },
-        "tar-pack": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
-          "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
-          "dev": true,
-          "optional": true
-        },
-        "tough-cookie": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-          "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-          "dev": true,
-          "optional": true
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-          "dev": true,
-          "optional": true
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-          "dev": true,
-          "optional": true
-        },
-        "uid-number": {
-          "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-          "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
-          "dev": true,
-          "optional": true
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-          "dev": true
-        },
-        "uuid": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-          "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
-          "dev": true,
-          "optional": true
-        },
-        "verror": {
-          "version": "1.3.6",
-          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-          "dev": true,
-          "optional": true
-        },
-        "wide-align": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
-          "dev": true,
-          "optional": true
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
-        }
-      }
-    },
     "fstream": {
       "version": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz"
+      }
     },
     "function-bind": {
       "version": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
@@ -2991,12 +4047,25 @@
     "gauge": {
       "version": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "aproba": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz",
+        "console-control-strings": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+        "has-unicode": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+        "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+        "wide-align": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz"
+      }
     },
     "gaze": {
       "version": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
       "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "globule": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz"
+      }
     },
     "generate-function": {
       "version": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
@@ -3006,12 +4075,28 @@
     "generate-object-property": {
       "version": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-property": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+      }
     },
     "get-caller-file": {
       "version": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
       "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
       "dev": true
+    },
+    "get-pkg-repo": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-1.4.0.tgz",
+      "integrity": "sha1-xztInAbYDMVTbCyFP54FIyBWly0=",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+        "meow": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+        "normalize-package-data": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+        "parse-github-repo-url": "1.4.1",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+      }
     },
     "get-stdin": {
       "version": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
@@ -3022,6 +4107,9 @@
       "version": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
+      "requires": {
+        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -3033,32 +4121,119 @@
     "gift": {
       "version": "https://registry.npmjs.org/gift/-/gift-0.6.1.tgz",
       "integrity": "sha1-wWmOa2iHFk7ZeKAQlUI8/2W4558=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "underscore": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
+      }
+    },
+    "git-raw-commits": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.2.0.tgz",
+      "integrity": "sha1-DzqL/ZmuDy2LkiTViJKXXppS0Dw=",
+      "dev": true,
+      "requires": {
+        "dargs": "4.1.0",
+        "lodash.template": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+        "meow": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+        "split2": "2.2.0",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+      }
+    },
+    "git-remote-origin-url": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
+      "integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
+      "dev": true,
+      "requires": {
+        "gitconfiglocal": "1.0.0",
+        "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+      }
+    },
+    "git-semver-tags": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.2.2.tgz",
+      "integrity": "sha512-fhINopzKBQ8m6YlQt7gPf6T6hFnTF84O7U+8kYJmfjjKk7gbmKGj+BLcKNWi+japPbBwCeXXnfKwThpJpR9ZnQ==",
+      "dev": true,
+      "requires": {
+        "meow": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+        "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
+      }
+    },
+    "gitconfiglocal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
+      "integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
+      "dev": true,
+      "requires": {
+        "ini": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+      }
+    },
+    "glamor": {
+      "version": "2.20.40",
+      "resolved": "https://registry.npmjs.org/glamor/-/glamor-2.20.40.tgz",
+      "integrity": "sha512-DNXCd+c14N9QF8aAKrfl4xakPk5FdcFwmH7sD0qnC0Pr7xoZ5W9yovhUrY/dJc3psfGGXC58vqQyRtuskyUJxA==",
+      "dev": true,
+      "requires": {
+        "fbjs": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz",
+        "inline-style-prefixer": "3.0.8",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "prop-types": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz",
+        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+      }
     },
     "glob": {
       "version": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
       "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+        "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+      }
     },
     "glob-base": {
       "version": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glob-parent": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+        "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
+      }
     },
     "glob-parent": {
       "version": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
+      }
     },
     "glob-stream": {
       "version": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
       "integrity": "sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=",
       "dev": true,
+      "requires": {
+        "glob": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+        "glob2base": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
+        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+        "ordered-read-streams": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+        "unique-stream": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz"
+      },
       "dependencies": {
         "glob": {
           "version": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
           "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
+          }
         },
         "isarray": {
           "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -3068,12 +4243,21 @@
         "minimatch": {
           "version": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz"
+          }
         },
         "readable-stream": {
           "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+          }
         },
         "string_decoder": {
           "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
@@ -3083,24 +4267,44 @@
         "through2": {
           "version": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+            "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+          }
         }
       }
+    },
+    "glob-to-regexp": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
+      "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
+      "dev": true
     },
     "glob-watcher": {
       "version": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
       "integrity": "sha1-uVtKjfdLOcgymLDAXJeLTZo7cQs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "gaze": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz"
+      }
     },
     "glob2base": {
       "version": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
       "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "find-index": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz"
+      }
     },
     "global-modules": {
       "version": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
       "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
       "dev": true,
+      "requires": {
+        "global-prefix": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
+        "is-windows": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz"
+      },
       "dependencies": {
         "is-windows": {
           "version": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
@@ -3113,6 +4317,12 @@
       "version": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
       "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
       "dev": true,
+      "requires": {
+        "homedir-polyfill": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
+        "ini": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+        "is-windows": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+        "which": "https://registry.npmjs.org/which/-/which-1.2.14.tgz"
+      },
       "dependencies": {
         "is-windows": {
           "version": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
@@ -3129,17 +4339,35 @@
     "globby": {
       "version": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-union": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+        "arrify": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+      }
     },
     "globule": {
       "version": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
       "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
       "dev": true,
+      "requires": {
+        "glob": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
+        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz"
+      },
       "dependencies": {
         "glob": {
           "version": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz"
+          }
         },
         "graceful-fs": {
           "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
@@ -3164,14 +4392,31 @@
         "minimatch": {
           "version": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lru-cache": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+            "sigmund": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+          }
         }
       }
     },
     "glogg": {
       "version": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
       "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "sparkles": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
+      }
+    },
+    "good-listener": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "delegate": "3.1.3"
+      }
     },
     "graceful-fs": {
       "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
@@ -3197,6 +4442,21 @@
       "version": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
       "integrity": "sha1-VxzkWSjdQK9lFPxAEYZgFsE4RbQ=",
       "dev": true,
+      "requires": {
+        "archy": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "deprecated": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz",
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "interpret": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
+        "liftoff": "https://registry.npmjs.org/liftoff/-/liftoff-2.3.0.tgz",
+        "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+        "orchestrator": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.8.tgz",
+        "pretty-hrtime": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
+        "semver": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+        "tildify": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
+        "v8flags": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
+        "vinyl-fs": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz"
+      },
       "dependencies": {
         "minimist": {
           "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
@@ -3213,17 +4473,37 @@
     "gulp-babel": {
       "version": "https://registry.npmjs.org/gulp-babel/-/gulp-babel-6.1.2.tgz",
       "integrity": "sha1-fAF25Lo/JExgWIoMSzIKRdGt784=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-core": "https://registry.npmjs.org/babel-core/-/babel-core-6.24.1.tgz",
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "replace-ext": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+        "vinyl-sourcemaps-apply": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz"
+      }
     },
     "gulp-bump": {
       "version": "https://registry.npmjs.org/gulp-bump/-/gulp-bump-2.7.0.tgz",
       "integrity": "sha1-TDdQvOk8XYFv6aFU5mGd1QmoUtg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "bump-regex": "https://registry.npmjs.org/bump-regex/-/bump-regex-2.7.0.tgz",
+        "plugin-error": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
+        "plugin-log": "https://registry.npmjs.org/plugin-log/-/plugin-log-0.1.0.tgz",
+        "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+      }
     },
     "gulp-cheerio": {
       "version": "https://registry.npmjs.org/gulp-cheerio/-/gulp-cheerio-0.6.2.tgz",
       "integrity": "sha1-dQYzkVFvx5KXS+w8EFGdfJKB6SE=",
       "dev": true,
+      "requires": {
+        "cheerio": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz"
+      },
       "dependencies": {
         "ansi-regex": {
           "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
@@ -3238,29 +4518,57 @@
         "chalk": {
           "version": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+            "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "has-ansi": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+          }
         },
         "dateformat": {
           "version": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
           "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "get-stdin": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+            "meow": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz"
+          }
         },
         "gulp-util": {
           "version": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz",
           "integrity": "sha1-1xRuVyiRC9jwR6awseVJvCLb1kw=",
           "dev": true,
+          "requires": {
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+            "dateformat": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
+            "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
+            "lodash.template": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
+            "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
+            "multipipe": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+            "through2": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+            "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz"
+          },
           "dependencies": {
             "through2": {
               "version": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
               "integrity": "sha1-390BLrnHAOIyP9M084rGIqs3Lac=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                "xtend": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
+              }
             }
           }
         },
         "has-ansi": {
           "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
           "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+          }
         },
         "isarray": {
           "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -3275,27 +4583,54 @@
         "lodash.defaults": {
           "version": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
           "integrity": "sha1-p+iIXwXmiFEUS24SqPNngCa8TFQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._objecttypes": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+            "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz"
+          }
         },
         "lodash.escape": {
           "version": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
           "integrity": "sha1-LOEsXghNsKV92l5dHu659dF1o7Q=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._escapehtmlchar": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
+            "lodash._reunescapedhtml": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
+            "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz"
+          }
         },
         "lodash.keys": {
           "version": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
           "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._isnative": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+            "lodash._shimkeys": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
+            "lodash.isobject": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz"
+          }
         },
         "lodash.template": {
           "version": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
           "integrity": "sha1-nmEQB+32KRKal0qzxIuBez4c8g0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._escapestringchar": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz",
+            "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
+            "lodash.defaults": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
+            "lodash.escape": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
+            "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+            "lodash.templatesettings": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz",
+            "lodash.values": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz"
+          }
         },
         "lodash.templatesettings": {
           "version": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz",
           "integrity": "sha1-6nbHXRHrhtTb6JqDiTu4YZKaxpk=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
+            "lodash.escape": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz"
+          }
         },
         "minimist": {
           "version": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
@@ -3305,7 +4640,13 @@
         "readable-stream": {
           "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+          }
         },
         "string_decoder": {
           "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
@@ -3315,7 +4656,10 @@
         "strip-ansi": {
           "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
           "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+          }
         },
         "supports-color": {
           "version": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
@@ -3326,6 +4670,10 @@
           "version": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "dev": true,
+          "requires": {
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+            "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+          },
           "dependencies": {
             "xtend": {
               "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
@@ -3337,7 +4685,10 @@
         "vinyl": {
           "version": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz",
           "integrity": "sha1-vKk4IJWC7FpJrVOKAPofEl5RMlI=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+          }
         },
         "xtend": {
           "version": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
@@ -3349,42 +4700,88 @@
     "gulp-cond": {
       "version": "https://registry.npmjs.org/gulp-cond/-/gulp-cond-1.0.0.tgz",
       "integrity": "sha1-mYDDzcr6m8TNMKuHEIesE1lVtVg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz"
+      }
     },
     "gulp-consolidate": {
       "version": "https://registry.npmjs.org/gulp-consolidate/-/gulp-consolidate-0.2.0.tgz",
       "integrity": "sha1-7zc7YTSvMbD4xR9etV+qC9dU31I=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "consolidate": "https://registry.npmjs.org/consolidate/-/consolidate-0.14.5.tgz",
+        "map-stream": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.4.tgz"
+      }
     },
     "gulp-gh-pages": {
       "version": "https://registry.npmjs.org/gulp-gh-pages/-/gulp-gh-pages-0.5.4.tgz",
       "integrity": "sha1-pnMspHWrm1pTJTwcJHNMQMIbZUY=",
       "dev": true,
+      "requires": {
+        "gift": "https://registry.npmjs.org/gift/-/gift-0.6.1.tgz",
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+        "vinyl-fs": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
+        "wrap-promise": "https://registry.npmjs.org/wrap-promise/-/wrap-promise-1.0.1.tgz"
+      },
       "dependencies": {
         "glob": {
           "version": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+          }
         },
         "glob-parent": {
           "version": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+            "path-dirname": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz"
+          }
         },
         "glob-stream": {
           "version": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
           "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
           "dev": true,
+          "requires": {
+            "extend": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+            "glob": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+            "glob-parent": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+            "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+            "ordered-read-streams": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
+            "through2": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+            "to-absolute-glob": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
+            "unique-stream": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz"
+          },
           "dependencies": {
             "readable-stream": {
               "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
               "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+              }
             },
             "through2": {
               "version": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
               "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+              }
             }
           }
         },
@@ -3396,7 +4793,10 @@
         "is-glob": {
           "version": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz"
+          }
         },
         "isarray": {
           "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -3406,7 +4806,11 @@
         "ordered-read-streams": {
           "version": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
           "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-stream": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz"
+          }
         },
         "string_decoder": {
           "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
@@ -3416,17 +4820,45 @@
         "unique-stream": {
           "version": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
           "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "json-stable-stringify": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+            "through2-filter": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz"
+          }
         },
         "vinyl": {
           "version": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "clone": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+            "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+            "replace-ext": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+          }
         },
         "vinyl-fs": {
           "version": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
           "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "duplexify": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz",
+            "glob-stream": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
+            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+            "gulp-sourcemaps": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+            "is-valid-glob": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
+            "lazystream": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+            "lodash.isequal": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+            "merge-stream": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+            "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+            "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+            "strip-bom-stream": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
+            "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+            "through2-filter": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
+            "vali-date": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
+            "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz"
+          }
         }
       }
     },
@@ -3434,6 +4866,14 @@
       "version": "https://registry.npmjs.org/gulp-git/-/gulp-git-2.1.0.tgz",
       "integrity": "sha1-8JZhUp5OFWJrba59Mwgg2YcfnWU=",
       "dev": true,
+      "requires": {
+        "any-shell-escape": "https://registry.npmjs.org/any-shell-escape/-/any-shell-escape-0.1.1.tgz",
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "require-dir": "https://registry.npmjs.org/require-dir/-/require-dir-0.3.2.tgz",
+        "strip-bom-stream": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-3.0.0.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+        "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-2.0.2.tgz"
+      },
       "dependencies": {
         "clone-stats": {
           "version": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
@@ -3443,7 +4883,10 @@
         "first-chunk-stream": {
           "version": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz",
           "integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz"
+          }
         },
         "replace-ext": {
           "version": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
@@ -3453,29 +4896,66 @@
         "strip-bom-stream": {
           "version": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-3.0.0.tgz",
           "integrity": "sha1-lWvMXYRDD2klapDtgjdlzYWOFZw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "first-chunk-stream": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz",
+            "strip-bom-buf": "https://registry.npmjs.org/strip-bom-buf/-/strip-bom-buf-1.0.0.tgz"
+          }
         },
         "vinyl": {
           "version": "https://registry.npmjs.org/vinyl/-/vinyl-2.0.2.tgz",
           "integrity": "sha1-CjcT2NTpIhxY8QyhbAEWyeJe2nw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "clone": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+            "clone-buffer": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
+            "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+            "cloneable-readable": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.0.0.tgz",
+            "is-stream": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+            "remove-trailing-separator": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
+            "replace-ext": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz"
+          }
         }
       }
     },
     "gulp-iconfont": {
       "version": "https://registry.npmjs.org/gulp-iconfont/-/gulp-iconfont-8.0.1.tgz",
       "integrity": "sha1-vDKqbj6lyjifuwFLqNLAjww8B2M=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "gulp-cond": "https://registry.npmjs.org/gulp-cond/-/gulp-cond-1.0.0.tgz",
+        "gulp-spawn": "https://registry.npmjs.org/gulp-spawn/-/gulp-spawn-0.3.0.tgz",
+        "gulp-svg2ttf": "https://registry.npmjs.org/gulp-svg2ttf/-/gulp-svg2ttf-2.0.0.tgz",
+        "gulp-svgicons2svgfont": "https://registry.npmjs.org/gulp-svgicons2svgfont/-/gulp-svgicons2svgfont-3.0.1.tgz",
+        "gulp-ttf2eot": "https://registry.npmjs.org/gulp-ttf2eot/-/gulp-ttf2eot-1.1.1.tgz",
+        "gulp-ttf2woff": "https://registry.npmjs.org/gulp-ttf2woff/-/gulp-ttf2woff-1.1.0.tgz",
+        "gulp-ttf2woff2": "https://registry.npmjs.org/gulp-ttf2woff2/-/gulp-ttf2woff2-2.0.2.tgz",
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "plexer": "https://registry.npmjs.org/plexer/-/plexer-1.0.1.tgz",
+        "streamfilter": "https://registry.npmjs.org/streamfilter/-/streamfilter-1.0.5.tgz"
+      }
     },
     "gulp-json-editor": {
       "version": "https://registry.npmjs.org/gulp-json-editor/-/gulp-json-editor-2.2.1.tgz",
       "integrity": "sha1-fE3XR36NBtxdxJwLgedFzbBPl7s=",
       "dev": true,
+      "requires": {
+        "deepmerge": "https://registry.npmjs.org/deepmerge/-/deepmerge-0.2.10.tgz",
+        "detect-indent": "https://registry.npmjs.org/detect-indent/-/detect-indent-2.0.0.tgz",
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "js-beautify": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.5.10.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz"
+      },
       "dependencies": {
         "detect-indent": {
           "version": "https://registry.npmjs.org/detect-indent/-/detect-indent-2.0.0.tgz",
           "integrity": "sha1-cg/1Hk2Xt2iE9r9XKSNIsT396Tk=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "get-stdin": "https://registry.npmjs.org/get-stdin/-/get-stdin-3.0.2.tgz",
+            "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+            "repeating": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz"
+          }
         },
         "get-stdin": {
           "version": "https://registry.npmjs.org/get-stdin/-/get-stdin-3.0.2.tgz",
@@ -3495,12 +4975,21 @@
         "readable-stream": {
           "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+          }
         },
         "repeating": {
           "version": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
           "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-finite": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz"
+          }
         },
         "string_decoder": {
           "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
@@ -3510,7 +4999,11 @@
         "through2": {
           "version": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
           "integrity": "sha1-390BLrnHAOIyP9M084rGIqs3Lac=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+            "xtend": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
+          }
         },
         "xtend": {
           "version": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
@@ -3523,16 +5016,30 @@
       "version": "https://registry.npmjs.org/gulp-notify/-/gulp-notify-3.0.0.tgz",
       "integrity": "sha1-oEuK+azb5OY8hFZ4zgw9MGlMWaM=",
       "dev": true,
+      "requires": {
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "lodash.template": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
+        "node-notifier": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.1.2.tgz",
+        "node.extend": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.6.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+      },
       "dependencies": {
         "lodash.template": {
           "version": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
           "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+            "lodash.templatesettings": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz"
+          }
         },
         "lodash.templatesettings": {
           "version": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
           "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
+          }
         }
       }
     },
@@ -3543,23 +5050,48 @@
     },
     "gulp-rsvg": {
       "version": "git://github.com/junyper/gulp-rsvg.git#6a0329e32eb22fa1de25660def0b03b37d04ba7d",
-      "integrity": "sha1-Z8GY4IfNvNMKKzONI+31LGbDO3M=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+      }
     },
     "gulp-sketch": {
       "version": "https://registry.npmjs.org/gulp-sketch/-/gulp-sketch-1.0.5.tgz",
       "integrity": "sha1-smVf9qi2eV3Cdbt9bZNud6NAcPc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "clean-sketch": "https://registry.npmjs.org/clean-sketch/-/clean-sketch-1.0.1.tgz",
+        "es6-promise": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.0.tgz",
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "npm-which": "https://registry.npmjs.org/npm-which/-/npm-which-3.0.1.tgz",
+        "recursive-readdir": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.1.tgz",
+        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+        "temporary": "https://registry.npmjs.org/temporary/-/temporary-0.0.8.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+      }
     },
     "gulp-sourcemaps": {
       "version": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
       "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
       "dev": true,
+      "requires": {
+        "convert-source-map": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+        "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz"
+      },
       "dependencies": {
         "vinyl": {
           "version": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "clone": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+            "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+            "replace-ext": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+          }
         }
       }
     },
@@ -3567,6 +5099,10 @@
       "version": "https://registry.npmjs.org/gulp-spawn/-/gulp-spawn-0.3.0.tgz",
       "integrity": "sha1-Qg+qjQcOy2DLgxYAKTayVCOcVuw=",
       "dev": true,
+      "requires": {
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz",
+        "plexer": "https://registry.npmjs.org/plexer/-/plexer-0.0.1.tgz"
+      },
       "dependencies": {
         "ansi-regex": {
           "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
@@ -3581,22 +5117,46 @@
         "chalk": {
           "version": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+            "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "has-ansi": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+          }
         },
         "dateformat": {
           "version": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
           "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "get-stdin": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+            "meow": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz"
+          }
         },
         "gulp-util": {
           "version": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz",
           "integrity": "sha1-1xRuVyiRC9jwR6awseVJvCLb1kw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+            "dateformat": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
+            "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
+            "lodash.template": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
+            "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
+            "multipipe": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+            "through2": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+            "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz"
+          }
         },
         "has-ansi": {
           "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
           "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+          }
         },
         "isarray": {
           "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -3611,27 +5171,54 @@
         "lodash.defaults": {
           "version": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
           "integrity": "sha1-p+iIXwXmiFEUS24SqPNngCa8TFQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._objecttypes": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+            "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz"
+          }
         },
         "lodash.escape": {
           "version": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
           "integrity": "sha1-LOEsXghNsKV92l5dHu659dF1o7Q=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._escapehtmlchar": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
+            "lodash._reunescapedhtml": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
+            "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz"
+          }
         },
         "lodash.keys": {
           "version": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
           "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._isnative": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+            "lodash._shimkeys": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
+            "lodash.isobject": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz"
+          }
         },
         "lodash.template": {
           "version": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
           "integrity": "sha1-nmEQB+32KRKal0qzxIuBez4c8g0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._escapestringchar": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz",
+            "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
+            "lodash.defaults": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
+            "lodash.escape": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
+            "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+            "lodash.templatesettings": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz",
+            "lodash.values": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz"
+          }
         },
         "lodash.templatesettings": {
           "version": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz",
           "integrity": "sha1-6nbHXRHrhtTb6JqDiTu4YZKaxpk=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
+            "lodash.escape": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz"
+          }
         },
         "minimist": {
           "version": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
@@ -3646,7 +5233,13 @@
         "readable-stream": {
           "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+          }
         },
         "string_decoder": {
           "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
@@ -3656,7 +5249,10 @@
         "strip-ansi": {
           "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
           "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+          }
         },
         "supports-color": {
           "version": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
@@ -3666,12 +5262,19 @@
         "through2": {
           "version": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
           "integrity": "sha1-390BLrnHAOIyP9M084rGIqs3Lac=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+            "xtend": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
+          }
         },
         "vinyl": {
           "version": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz",
           "integrity": "sha1-vKk4IJWC7FpJrVOKAPofEl5RMlI=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+          }
         },
         "xtend": {
           "version": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
@@ -3683,27 +5286,52 @@
     "gulp-svg2ttf": {
       "version": "https://registry.npmjs.org/gulp-svg2ttf/-/gulp-svg2ttf-2.0.0.tgz",
       "integrity": "sha1-l9Fv+hlOzQNCduGnodw0mee2364=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "bufferstreams": "https://registry.npmjs.org/bufferstreams/-/bufferstreams-1.1.1.tgz",
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+        "svg2ttf": "https://registry.npmjs.org/svg2ttf/-/svg2ttf-4.1.0.tgz"
+      }
     },
     "gulp-svgicons2svgfont": {
       "version": "https://registry.npmjs.org/gulp-svgicons2svgfont/-/gulp-svgicons2svgfont-3.0.1.tgz",
       "integrity": "sha1-AzpVgsyTtQbuZU5iLUPp5qQpRSU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "plexer": "https://registry.npmjs.org/plexer/-/plexer-1.0.1.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+        "svgicons2svgfont": "https://registry.npmjs.org/svgicons2svgfont/-/svgicons2svgfont-5.0.1.tgz"
+      }
     },
     "gulp-svgmin": {
       "version": "https://registry.npmjs.org/gulp-svgmin/-/gulp-svgmin-1.2.4.tgz",
       "integrity": "sha1-pKqeJhXPEQXvVVrqhuhilswg4nM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "svgo": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz"
+      }
     },
     "gulp-svgstore": {
       "version": "https://registry.npmjs.org/gulp-svgstore/-/gulp-svgstore-6.1.0.tgz",
       "integrity": "sha1-BLIDrA4T+O1tv8lA0lllxOJFZnY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "cheerio": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz"
+      }
     },
     "gulp-tag-version": {
       "version": "https://registry.npmjs.org/gulp-tag-version/-/gulp-tag-version-1.3.0.tgz",
       "integrity": "sha1-hEjIfu0YZtuObLWYvEGb4t98R9s=",
       "dev": true,
+      "requires": {
+        "gulp-git": "https://registry.npmjs.org/gulp-git/-/gulp-git-0.3.6.tgz",
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz",
+        "map-stream": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz"
+      },
       "dependencies": {
         "ansi-regex": {
           "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
@@ -3718,34 +5346,68 @@
         "chalk": {
           "version": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+            "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "has-ansi": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+          }
         },
         "dateformat": {
           "version": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
           "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "get-stdin": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+            "meow": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz"
+          }
         },
         "gulp-git": {
           "version": "https://registry.npmjs.org/gulp-git/-/gulp-git-0.3.6.tgz",
           "integrity": "sha1-d+w9oiklwkbt15bKENQWOWXYFAo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "any-shell-escape": "https://registry.npmjs.org/any-shell-escape/-/any-shell-escape-0.1.1.tgz",
+            "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz",
+            "map-stream": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+            "through2": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz"
+          }
         },
         "gulp-util": {
           "version": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz",
           "integrity": "sha1-1xRuVyiRC9jwR6awseVJvCLb1kw=",
           "dev": true,
+          "requires": {
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+            "dateformat": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
+            "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
+            "lodash.template": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
+            "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
+            "multipipe": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+            "through2": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+            "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz"
+          },
           "dependencies": {
             "through2": {
               "version": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
               "integrity": "sha1-390BLrnHAOIyP9M084rGIqs3Lac=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                "xtend": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
+              }
             }
           }
         },
         "has-ansi": {
           "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
           "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+          }
         },
         "isarray": {
           "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -3760,27 +5422,54 @@
         "lodash.defaults": {
           "version": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
           "integrity": "sha1-p+iIXwXmiFEUS24SqPNngCa8TFQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._objecttypes": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+            "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz"
+          }
         },
         "lodash.escape": {
           "version": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
           "integrity": "sha1-LOEsXghNsKV92l5dHu659dF1o7Q=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._escapehtmlchar": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
+            "lodash._reunescapedhtml": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
+            "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz"
+          }
         },
         "lodash.keys": {
           "version": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
           "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._isnative": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+            "lodash._shimkeys": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
+            "lodash.isobject": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz"
+          }
         },
         "lodash.template": {
           "version": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
           "integrity": "sha1-nmEQB+32KRKal0qzxIuBez4c8g0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._escapestringchar": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz",
+            "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
+            "lodash.defaults": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
+            "lodash.escape": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
+            "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+            "lodash.templatesettings": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz",
+            "lodash.values": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz"
+          }
         },
         "lodash.templatesettings": {
           "version": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz",
           "integrity": "sha1-6nbHXRHrhtTb6JqDiTu4YZKaxpk=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
+            "lodash.escape": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz"
+          }
         },
         "map-stream": {
           "version": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
@@ -3800,7 +5489,13 @@
         "readable-stream": {
           "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+          }
         },
         "string_decoder": {
           "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
@@ -3810,7 +5505,10 @@
         "strip-ansi": {
           "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
           "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+          }
         },
         "supports-color": {
           "version": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
@@ -3821,18 +5519,28 @@
           "version": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
           "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
           "dev": true,
+          "requires": {
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+            "xtend": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz"
+          },
           "dependencies": {
             "xtend": {
               "version": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
               "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "object-keys": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
+              }
             }
           }
         },
         "vinyl": {
           "version": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz",
           "integrity": "sha1-vKk4IJWC7FpJrVOKAPofEl5RMlI=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+          }
         },
         "xtend": {
           "version": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
@@ -3844,22 +5552,60 @@
     "gulp-ttf2eot": {
       "version": "https://registry.npmjs.org/gulp-ttf2eot/-/gulp-ttf2eot-1.1.1.tgz",
       "integrity": "sha1-3pWEoWxP9OPFgVs9XrGXfsxU01w=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "bufferstreams": "https://registry.npmjs.org/bufferstreams/-/bufferstreams-1.1.1.tgz",
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+        "ttf2eot": "https://registry.npmjs.org/ttf2eot/-/ttf2eot-1.3.0.tgz"
+      }
     },
     "gulp-ttf2woff": {
       "version": "https://registry.npmjs.org/gulp-ttf2woff/-/gulp-ttf2woff-1.1.0.tgz",
       "integrity": "sha1-Oi7eUxWPAqYyP9b026AIsuswuls=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "bufferstreams": "https://registry.npmjs.org/bufferstreams/-/bufferstreams-1.1.1.tgz",
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+        "ttf2woff": "https://registry.npmjs.org/ttf2woff/-/ttf2woff-1.3.0.tgz"
+      }
     },
     "gulp-ttf2woff2": {
       "version": "https://registry.npmjs.org/gulp-ttf2woff2/-/gulp-ttf2woff2-2.0.2.tgz",
       "integrity": "sha1-8QGxUg8jaqZ2fsRb9HVByxWe6zI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "bufferstreams": "https://registry.npmjs.org/bufferstreams/-/bufferstreams-1.1.1.tgz",
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+        "ttf2woff2": "https://registry.npmjs.org/ttf2woff2/-/ttf2woff2-2.0.3.tgz"
+      }
     },
     "gulp-util": {
       "version": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
       "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
       "dev": true,
+      "requires": {
+        "array-differ": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+        "array-uniq": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+        "beeper": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "dateformat": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
+        "fancy-log": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
+        "gulplog": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+        "has-gulplog": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+        "lodash._reescape": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+        "lodash._reevaluate": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+        "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+        "lodash.template": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+        "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+        "multipipe": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+        "replace-ext": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+        "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz"
+      },
       "dependencies": {
         "minimist": {
           "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
@@ -3877,11 +5623,27 @@
       "version": "https://registry.npmjs.org/gulp-watch/-/gulp-watch-4.3.11.tgz",
       "integrity": "sha1-Fi/FY96fx3DpH5p845VVE6mhGMA=",
       "dev": true,
+      "requires": {
+        "anymatch": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
+        "chokidar": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.1.tgz",
+        "glob-parent": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+        "slash": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+        "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+        "vinyl-file": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-2.0.0.tgz"
+      },
       "dependencies": {
         "glob-parent": {
           "version": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+            "path-dirname": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz"
+          }
         },
         "is-extglob": {
           "version": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -3891,19 +5653,42 @@
         "is-glob": {
           "version": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz"
+          }
         },
         "vinyl": {
           "version": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "clone": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+            "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+            "replace-ext": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+          }
         }
       }
     },
     "gulplog": {
       "version": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
       "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glogg": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz"
+      }
+    },
+    "handlebars": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
+      "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
+      "dev": true,
+      "requires": {
+        "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+        "optimist": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+        "uglify-js": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.0.21.tgz"
+      }
     },
     "har-schema": {
       "version": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
@@ -3913,22 +5698,37 @@
     "har-validator": {
       "version": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
       "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "commander": "https://registry.npmjs.org/commander/-/commander-2.10.0.tgz",
+        "is-my-json-valid": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
+        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+      }
     },
     "has": {
       "version": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "function-bind": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
+      }
     },
     "has-ansi": {
       "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+      }
     },
     "has-binary": {
       "version": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
       "integrity": "sha1-aOYesWIQyVRaClzOBqhzkS/h5ow=",
       "dev": true,
+      "requires": {
+        "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+      },
       "dependencies": {
         "isarray": {
           "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -3950,7 +5750,10 @@
     "has-gulplog": {
       "version": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
       "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "sparkles": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
+      }
     },
     "has-unicode": {
       "version": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
@@ -3960,17 +5763,30 @@
     "hash-base": {
       "version": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
       "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+      }
     },
     "hash.js": {
       "version": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.2.tgz",
       "integrity": "sha1-v1yIeCXP5Aue/ee/Eb0tsm5r8Bs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "minimalistic-assert": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
+      }
     },
     "hawk": {
       "version": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
       "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+        "cryptiles": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+        "sntp": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+      }
     },
     "he": {
       "version": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
@@ -3980,7 +5796,12 @@
     "hmac-drbg": {
       "version": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "hash.js": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.2.tgz",
+        "minimalistic-assert": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+        "minimalistic-crypto-utils": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz"
+      }
     },
     "hoek": {
       "version": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
@@ -3990,12 +5811,19 @@
     "home-or-tmp": {
       "version": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+        "os-tmpdir": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
+      }
     },
     "homedir-polyfill": {
       "version": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
       "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "parse-passwd": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz"
+      }
     },
     "hosted-git-info": {
       "version": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
@@ -4010,48 +5838,100 @@
     "html-encoding-sniffer": {
       "version": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.1.tgz",
       "integrity": "sha1-eb96eF6klf5mFl5zQVPzY/9UN9o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "whatwg-encoding": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.1.tgz"
+      }
     },
     "html-minifier": {
       "version": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.2.tgz",
       "integrity": "sha1-1zvD/0SJQkCIGM5gm/P7DqfvTrc=",
       "dev": true,
+      "requires": {
+        "camel-case": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
+        "clean-css": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.5.tgz",
+        "commander": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+        "he": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+        "ncname": "https://registry.npmjs.org/ncname/-/ncname-1.0.0.tgz",
+        "param-case": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
+        "relateurl": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
+        "uglify-js": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.0.21.tgz"
+      },
       "dependencies": {
         "commander": {
           "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
           "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-readlink": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+          }
         }
       }
     },
     "html-webpack-plugin": {
       "version": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-2.28.0.tgz",
       "integrity": "sha1-LnhjtX5f1I/iYzA+L/yTTDBk0Ak=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "bluebird": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+        "html-minifier": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.2.tgz",
+        "loader-utils": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+        "pretty-error": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.1.tgz",
+        "toposort": "https://registry.npmjs.org/toposort/-/toposort-1.0.3.tgz"
+      }
     },
     "htmlparser2": {
       "version": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
       "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "domelementtype": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+        "domhandler": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz",
+        "domutils": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+        "entities": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz"
+      }
     },
     "http-errors": {
       "version": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
       "integrity": "sha1-eIwNLB3iyBuebowBhDtrl+uSB1A=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "setprototypeof": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz",
+        "statuses": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
+      }
     },
     "http-proxy": {
       "version": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.15.2.tgz",
       "integrity": "sha1-ZC/cr/5S00SNK9o7AHnpQJBk2jE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "eventemitter3": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
+        "requires-port": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
+      }
     },
     "http-signature": {
       "version": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
       "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+        "jsprim": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+        "sshpk": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz"
+      }
     },
     "https-browserify": {
       "version": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
       "integrity": "sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI=",
+      "dev": true
+    },
+    "hyphenate-style-name": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz",
+      "integrity": "sha1-MRYKNpMK2vH8BMYHT360FGXU7Es=",
       "dev": true
     },
     "iconv-lite": {
@@ -4086,7 +5966,10 @@
     "indent-string": {
       "version": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "repeating": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz"
+      }
     },
     "indexes-of": {
       "version": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
@@ -4101,7 +5984,11 @@
     "inflight": {
       "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+        "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+      }
     },
     "inherits": {
       "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
@@ -4113,10 +6000,59 @@
       "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
       "dev": true
     },
+    "inline-style-prefixer": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-3.0.8.tgz",
+      "integrity": "sha1-hVG45bTVcyROZqNLBPfTIHaitTQ=",
+      "dev": true,
+      "requires": {
+        "bowser": "1.8.0",
+        "css-in-js-utils": "2.0.0"
+      }
+    },
     "inquirer": {
       "version": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
       "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+        "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "cli-cursor": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+        "cli-width": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
+        "figures": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+        "readline2": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+        "run-async": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+        "rx-lite": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
+        "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+      }
+    },
+    "instructure-ui": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/instructure-ui/-/instructure-ui-3.4.0.tgz",
+      "integrity": "sha512-9kvXgtVdmK8hC97kwa4nuz+0qKFXXdohYvvqB2tudlLLkCgCsWoY7ZKiXTfg8IgyATXSV1tTWua4EfAijGOssw==",
+      "dev": true,
+      "requires": {
+        "bowser": "1.8.0",
+        "classnames": "2.2.5",
+        "decimal.js": "7.3.0",
+        "deep-equal": "1.0.1",
+        "glamor": "2.20.40",
+        "glob-to-regexp": "0.3.0",
+        "jscodeshift": "0.3.32",
+        "keycode": "2.1.9",
+        "moment-timezone": "0.5.13",
+        "no-scroll": "2.1.0",
+        "numeral": "2.0.6",
+        "object.omit": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+        "object.pick": "https://registry.npmjs.org/object.pick/-/object.pick-1.2.0.tgz",
+        "prop-types": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz",
+        "shortid": "https://registry.npmjs.org/shortid/-/shortid-2.2.8.tgz",
+        "tinycolor2": "1.4.1"
+      }
     },
     "interpret": {
       "version": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
@@ -4126,7 +6062,10 @@
     "invariant": {
       "version": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
       "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "loose-envify": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz"
+      }
     },
     "invert-kv": {
       "version": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
@@ -4141,6 +6080,10 @@
       "version": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz",
       "integrity": "sha1-IN5p89uULvLYe5wto28XIjWxtes=",
       "dev": true,
+      "requires": {
+        "is-relative": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
+        "is-windows": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz"
+      },
       "dependencies": {
         "is-windows": {
           "version": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
@@ -4162,7 +6105,10 @@
     "is-binary-path": {
       "version": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "binary-extensions": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.8.0.tgz"
+      }
     },
     "is-buffer": {
       "version": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
@@ -4172,7 +6118,10 @@
     "is-builtin-module": {
       "version": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "builtin-modules": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
+      }
     },
     "is-callable": {
       "version": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
@@ -4197,7 +6146,10 @@
     "is-equal-shallow": {
       "version": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-primitive": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+      }
     },
     "is-extendable": {
       "version": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -4212,30 +6164,57 @@
     "is-finite": {
       "version": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+      }
     },
     "is-fullwidth-code-point": {
       "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs="
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "requires": {
+        "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+      }
     },
     "is-glob": {
       "version": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+      }
     },
     "is-my-json-valid": {
       "version": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
       "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "generate-function": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+        "generate-object-property": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+        "jsonpointer": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+        "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+      }
     },
     "is-number": {
       "version": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
+      }
     },
     "is-number-like": {
       "version": "https://registry.npmjs.org/is-number-like/-/is-number-like-1.0.8.tgz",
       "integrity": "sha1-LhKWILUIkQQuROm7uzBZPnXPu+M=",
+      "dev": true,
+      "requires": {
+        "lodash.isfinite": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz"
+      }
+    },
+    "is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
     "is-path-cwd": {
@@ -4246,12 +6225,18 @@
     "is-path-in-cwd": {
       "version": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-path-inside": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz"
+      }
     },
     "is-path-inside": {
       "version": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
       "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "path-is-inside": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz"
+      }
     },
     "is-plain-obj": {
       "version": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
@@ -4262,6 +6247,9 @@
       "version": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.3.tgz",
       "integrity": "sha1-wVvz5LZrYtcu+vKSWEhmPsvGGbY=",
       "dev": true,
+      "requires": {
+        "isobject": "https://registry.npmjs.org/isobject/-/isobject-3.0.0.tgz"
+      },
       "dependencies": {
         "isobject": {
           "version": "https://registry.npmjs.org/isobject/-/isobject-3.0.0.tgz",
@@ -4288,31 +6276,58 @@
     "is-regex": {
       "version": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "has": "https://registry.npmjs.org/has/-/has-1.0.1.tgz"
+      }
     },
     "is-relative": {
       "version": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
       "integrity": "sha1-0n9MfVFtF1+2ENuEu+7yPDvJeqU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-unc-path": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz"
+      }
     },
     "is-resolvable": {
       "version": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
       "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "tryit": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz"
+      }
     },
     "is-stream": {
       "version": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
+    "is-subset": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
+      "integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
+      "dev": true
+    },
     "is-svg": {
       "version": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
       "integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "html-comment-regex": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.1.tgz"
+      }
     },
     "is-symbol": {
       "version": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
       "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
       "dev": true
+    },
+    "is-text-path": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
+      "integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
+      "dev": true,
+      "requires": {
+        "text-extensions": "1.7.0"
+      }
     },
     "is-typedarray": {
       "version": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
@@ -4322,7 +6337,10 @@
     "is-unc-path": {
       "version": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz",
       "integrity": "sha1-arBTpyVzwQJQ/0FqOBTDUXivObk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "unc-path-regex": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz"
+      }
     },
     "is-utf8": {
       "version": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
@@ -4352,11 +6370,18 @@
     "isobject": {
       "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
       "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+      }
     },
     "isomorphic-fetch": {
       "version": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk="
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "requires": {
+        "node-fetch": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.1.tgz",
+        "whatwg-fetch": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz"
+      }
     },
     "isstream": {
       "version": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -4371,7 +6396,12 @@
     "js-beautify": {
       "version": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.5.10.tgz",
       "integrity": "sha1-TZU3FwJpk0SlFsomv1nwonu3Vxk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "config-chain": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "nopt": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz"
+      }
     },
     "js-tokens": {
       "version": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -4380,7 +6410,11 @@
     "js-yaml": {
       "version": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
       "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "argparse": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+        "esprima": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz"
+      }
     },
     "jsbn": {
       "version": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
@@ -4388,10 +6422,55 @@
       "dev": true,
       "optional": true
     },
+    "jscodeshift": {
+      "version": "0.3.32",
+      "resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-0.3.32.tgz",
+      "integrity": "sha1-3s5etgLxY0DY2VTH+WrJB8UC6rs=",
+      "dev": true,
+      "requires": {
+        "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+        "babel-core": "https://registry.npmjs.org/babel-core/-/babel-core-6.24.1.tgz",
+        "babel-plugin-transform-flow-strip-types": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
+        "babel-preset-es2015": "6.24.1",
+        "babel-preset-stage-1": "https://registry.npmjs.org/babel-preset-stage-1/-/babel-preset-stage-1-6.24.1.tgz",
+        "babel-register": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
+        "babylon": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz",
+        "colors": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+        "flow-parser": "0.56.0",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+        "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+        "node-dir": "0.1.8",
+        "nomnom": "1.8.1",
+        "recast": "0.12.7",
+        "temp": "0.8.3",
+        "write-file-atomic": "1.3.4"
+      }
+    },
     "jsdom": {
       "version": "https://registry.npmjs.org/jsdom/-/jsdom-9.12.0.tgz",
       "integrity": "sha1-6MVG//ywbADUgzyoRBD+1/igl9Q=",
       "dev": true,
+      "requires": {
+        "abab": "https://registry.npmjs.org/abab/-/abab-1.0.3.tgz",
+        "acorn": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+        "acorn-globals": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz",
+        "array-equal": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+        "content-type-parser": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.1.tgz",
+        "cssom": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
+        "cssstyle": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
+        "escodegen": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+        "html-encoding-sniffer": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.1.tgz",
+        "nwmatcher": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.1.tgz",
+        "parse5": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
+        "request": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+        "sax": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+        "symbol-tree": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
+        "tough-cookie": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+        "webidl-conversions": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.1.tgz",
+        "whatwg-encoding": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.1.tgz",
+        "whatwg-url": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-4.8.0.tgz",
+        "xml-name-validator": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz"
+      },
       "dependencies": {
         "acorn": {
           "version": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
@@ -4406,7 +6485,11 @@
         "har-validator": {
           "version": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
           "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ajv": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+            "har-schema": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz"
+          }
         },
         "qs": {
           "version": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
@@ -4416,12 +6499,39 @@
         "request": {
           "version": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
           "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "aws-sign2": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+            "aws4": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+            "caseless": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+            "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+            "extend": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+            "forever-agent": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+            "form-data": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+            "har-validator": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+            "hawk": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+            "http-signature": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+            "is-typedarray": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+            "isstream": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+            "json-stringify-safe": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+            "oauth-sign": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+            "performance-now": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+            "qs": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+            "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+            "stringstream": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+            "tough-cookie": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+            "tunnel-agent": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+            "uuid": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz"
+          }
         },
         "tunnel-agent": {
           "version": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
           "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+          }
         },
         "uuid": {
           "version": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
@@ -4448,7 +6558,10 @@
     "json-stable-stringify": {
       "version": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "jsonify": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+      }
     },
     "json-stringify-safe": {
       "version": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -4468,11 +6581,20 @@
     "jsonfile": {
       "version": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+      }
     },
     "jsonify": {
       "version": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "dev": true
+    },
+    "jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
     },
     "jsonpointer": {
@@ -4480,10 +6602,26 @@
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
     },
+    "JSONStream": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+      "dev": true,
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+      }
+    },
     "jsprim": {
       "version": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
       "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
       "dev": true,
+      "requires": {
+        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+        "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+        "json-schema": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+        "verror": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -4497,15 +6635,27 @@
       "integrity": "sha1-OGchPo3Xm/Ho8jAMDPwe+xgsDfE=",
       "dev": true
     },
+    "keycode": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.1.9.tgz",
+      "integrity": "sha1-lkojxU5IiUBbSGGlyfBIDUUUHfo=",
+      "dev": true
+    },
     "kind-of": {
       "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+      }
     },
     "klaw": {
       "version": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+      }
     },
     "lazy-cache": {
       "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
@@ -4515,26 +6665,42 @@
     "lazystream": {
       "version": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
       "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz"
+      }
     },
     "lcid": {
       "version": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU="
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "requires": {
+        "invert-kv": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
+      }
     },
     "levn": {
       "version": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true
-    },
-    "librsvg": {
-      "version": "https://registry.npmjs.org/librsvg/-/librsvg-0.7.0.tgz",
-      "integrity": "sha1-bUiFp61nM16PES9xFxv3eDj13jQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+        "type-check": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
+      }
     },
     "liftoff": {
       "version": "https://registry.npmjs.org/liftoff/-/liftoff-2.3.0.tgz",
       "integrity": "sha1-qY8v9nGD2Lp8+soQVIvX/wVQs4U=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "extend": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+        "findup-sync": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.3.tgz",
+        "fined": "https://registry.npmjs.org/fined/-/fined-1.1.0.tgz",
+        "flagged-respawn": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.2.tgz",
+        "lodash.isplainobject": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+        "lodash.isstring": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+        "lodash.mapvalues": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
+        "rechoir": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+        "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz"
+      }
     },
     "limiter": {
       "version": "https://registry.npmjs.org/limiter/-/limiter-1.1.2.tgz",
@@ -4544,12 +6710,23 @@
     "load-json-file": {
       "version": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "parse-json": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+        "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+        "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
+      }
     },
     "loader-fs-cache": {
       "version": "https://registry.npmjs.org/loader-fs-cache/-/loader-fs-cache-1.0.1.tgz",
       "integrity": "sha1-VuC/CL2XCLJqdltoUJhAyN7J/bw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "find-cache-dir": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+      }
     },
     "loader-runner": {
       "version": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.0.tgz",
@@ -4559,12 +6736,24 @@
     "loader-utils": {
       "version": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
       "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "big.js": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
+        "emojis-list": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+        "json5": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+      }
     },
     "localtunnel": {
       "version": "https://registry.npmjs.org/localtunnel/-/localtunnel-1.8.2.tgz",
       "integrity": "sha1-kTBR6DKLUfda2KIq0fXFuMWZo1k=",
       "dev": true,
+      "requires": {
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+        "openurl": "https://registry.npmjs.org/openurl/-/openurl-1.1.0.tgz",
+        "request": "https://registry.npmjs.org/request/-/request-2.78.0.tgz",
+        "yargs": "https://registry.npmjs.org/yargs/-/yargs-3.29.0.tgz"
+      },
       "dependencies": {
         "camelcase": {
           "version": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
@@ -4574,7 +6763,10 @@
         "debug": {
           "version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+          }
         },
         "ms": {
           "version": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
@@ -4584,7 +6776,15 @@
         "yargs": {
           "version": "https://registry.npmjs.org/yargs/-/yargs-3.29.0.tgz",
           "integrity": "sha1-GquWYOrnnYuPZ1vK7qtu40ws9pw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+            "cliui": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+            "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "os-locale": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+            "window-size": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+            "y18n": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz"
+          }
         }
       }
     },
@@ -4595,7 +6795,11 @@
     "lodash._baseassign": {
       "version": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+        "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
+      }
     },
     "lodash._basecopy": {
       "version": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
@@ -4620,7 +6824,10 @@
     "lodash._escapehtmlchar": {
       "version": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
       "integrity": "sha1-32fDu2t+jh6DGrSL+geVuSr+iZ0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._htmlescapes": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz"
+      }
     },
     "lodash._escapestringchar": {
       "version": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz",
@@ -4671,11 +6878,20 @@
       "version": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
       "integrity": "sha1-dHxPxAED6zu4oJduVx96JlnpO6c=",
       "dev": true,
+      "requires": {
+        "lodash._htmlescapes": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz",
+        "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz"
+      },
       "dependencies": {
         "lodash.keys": {
           "version": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
           "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._isnative": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+            "lodash._shimkeys": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
+            "lodash.isobject": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz"
+          }
         }
       }
     },
@@ -4687,7 +6903,10 @@
     "lodash._shimkeys": {
       "version": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
       "integrity": "sha1-bpzJZm/wgfC1psl4uD4kLmlJ0gM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._objecttypes": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+      }
     },
     "lodash.assignin": {
       "version": "https://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
@@ -4717,7 +6936,12 @@
     "lodash.create": {
       "version": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
       "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._baseassign": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+        "lodash._basecreate": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+        "lodash._isiterateecall": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+      }
     },
     "lodash.defaults": {
       "version": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
@@ -4727,7 +6951,10 @@
     "lodash.escape": {
       "version": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
       "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._root": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz"
+      }
     },
     "lodash.filter": {
       "version": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
@@ -4767,7 +6994,10 @@
     "lodash.isobject": {
       "version": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
       "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._objecttypes": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+      }
     },
     "lodash.isplainobject": {
       "version": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
@@ -4782,7 +7012,12 @@
     "lodash.keys": {
       "version": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+        "lodash.isarguments": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+        "lodash.isarray": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+      }
     },
     "lodash.map": {
       "version": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
@@ -4832,12 +7067,27 @@
     "lodash.template": {
       "version": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
       "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+        "lodash._basetostring": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+        "lodash._basevalues": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+        "lodash._isiterateecall": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+        "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+        "lodash.escape": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
+        "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+        "lodash.restparam": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+        "lodash.templatesettings": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz"
+      }
     },
     "lodash.templatesettings": {
       "version": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
       "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+        "lodash.escape": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz"
+      }
     },
     "lodash.uniq": {
       "version": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
@@ -4848,11 +7098,19 @@
       "version": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz",
       "integrity": "sha1-q/UUQ2s8twUAFieXjLzzCxKA7qQ=",
       "dev": true,
+      "requires": {
+        "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz"
+      },
       "dependencies": {
         "lodash.keys": {
           "version": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
           "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash._isnative": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+            "lodash._shimkeys": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
+            "lodash.isobject": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz"
+          }
         }
       }
     },
@@ -4863,12 +7121,19 @@
     },
     "loose-envify": {
       "version": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg="
+      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "requires": {
+        "js-tokens": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+      }
     },
     "loud-rejection": {
       "version": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "currently-unhandled": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+        "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
+      }
     },
     "lower-case": {
       "version": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
@@ -4878,12 +7143,25 @@
     "lru-cache": {
       "version": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
       "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pseudomap": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+        "yallist": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz"
+      }
     },
     "macaddress": {
       "version": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.8.tgz",
       "integrity": "sha1-WQTcU3w57G2+/q6QIycTX6hRHxI=",
       "dev": true
+    },
+    "magic-string": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.14.0.tgz",
+      "integrity": "sha1-VyJK7xcByu7Sc7F6OalW5ysXJGI=",
+      "dev": true,
+      "requires": {
+        "vlq": "0.2.3"
+      }
     },
     "map-cache": {
       "version": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
@@ -4900,6 +7178,12 @@
       "integrity": "sha1-XsbekCE+9sey65Nn6a3o2k79tos=",
       "dev": true
     },
+    "marked": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
+      "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc=",
+      "dev": true
+    },
     "math-expression-evaluator": {
       "version": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
       "integrity": "sha1-3oGf282E3M2PrlnGrreWFbnSZqw=",
@@ -4908,12 +7192,28 @@
     "memory-fs": {
       "version": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
       "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "errno": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz"
+      }
     },
     "meow": {
       "version": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
+      "requires": {
+        "camelcase-keys": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+        "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+        "loud-rejection": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+        "map-obj": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+        "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+        "normalize-package-data": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "read-pkg-up": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+        "redent": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+        "trim-newlines": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
+      },
       "dependencies": {
         "minimist": {
           "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
@@ -4922,10 +7222,19 @@
         }
       }
     },
+    "merge": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
+      "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
+      "dev": true
+    },
     "merge-stream": {
       "version": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
       "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz"
+      }
     },
     "microbuffer": {
       "version": "https://registry.npmjs.org/microbuffer/-/microbuffer-1.0.0.tgz",
@@ -4935,12 +7244,31 @@
     "micromatch": {
       "version": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "arr-diff": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+        "array-unique": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+        "braces": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+        "expand-brackets": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+        "extglob": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+        "filename-regex": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+        "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+        "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+        "normalize-path": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+        "object.omit": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+        "parse-glob": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+        "regex-cache": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz"
+      }
     },
     "miller-rabin": {
       "version": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz",
       "integrity": "sha1-SmL7HUKTPAVYOYL0xxb2+55sbT0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "bn.js": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.7.tgz",
+        "brorand": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz"
+      }
     },
     "mime": {
       "version": "https://registry.npmjs.org/mime/-/mime-1.2.4.tgz",
@@ -4955,7 +7283,10 @@
     "mime-types": {
       "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
       "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "mime-db": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz"
+      }
     },
     "minimalistic-assert": {
       "version": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
@@ -4970,7 +7301,10 @@
     "minimatch": {
       "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz"
+      }
     },
     "minimist": {
       "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
@@ -4980,22 +7314,44 @@
     "mkdirp": {
       "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+      }
     },
     "mocha": {
       "version": "https://registry.npmjs.org/mocha/-/mocha-3.4.2.tgz",
       "integrity": "sha1-0O9NMyEm2/GNDWQMmzgt1IvpdZQ=",
       "dev": true,
+      "requires": {
+        "browser-stdout": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+        "commander": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
+        "diff": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+        "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+        "growl": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+        "json3": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+        "lodash.create": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz"
+      },
       "dependencies": {
         "commander": {
           "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
           "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-readlink": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+          }
         },
         "debug": {
           "version": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
           "integrity": "sha1-vFlryr52F/Edn6FTYe3tVgi4SZs=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+          }
         },
         "ms": {
           "version": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
@@ -5005,7 +7361,10 @@
         "supports-color": {
           "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
           "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+          }
         }
       }
     },
@@ -5013,6 +7372,27 @@
       "version": "https://registry.npmjs.org/mocha-jsdom/-/mocha-jsdom-1.1.0.tgz",
       "integrity": "sha1-4VdvvQYBzInTWKIToOVYXRt8egE=",
       "dev": true
+    },
+    "modify-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.0.tgz",
+      "integrity": "sha1-4rbN65zhn5kxelNyLz2/XfXqqrI=",
+      "dev": true
+    },
+    "moment": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.0.tgz",
+      "integrity": "sha1-RPZ172uUSUJ2JYGxwXn7Z55ZnWc=",
+      "dev": true
+    },
+    "moment-timezone": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.13.tgz",
+      "integrity": "sha1-mc5cfYJyYusPH3AgRBd/YHRde5A=",
+      "dev": true,
+      "requires": {
+        "moment": "2.19.0"
+      }
     },
     "ms": {
       "version": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -5022,7 +7402,10 @@
     "multipipe": {
       "version": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
       "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "duplexer2": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz"
+      }
     },
     "mute-stream": {
       "version": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
@@ -5033,6 +7416,11 @@
       "version": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
       "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U=",
       "dev": true
+    },
+    "nanoid": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-0.2.2.tgz",
+      "integrity": "sha512-GHoRrvNEKiwdkwQ/enKL8AhQkkrBC/2KxMZkDvQzp8OtkpX8ZAmoYJWFVl7l8F2+HcEJUfdg21Ab2wXXfrvACQ=="
     },
     "natives": {
       "version": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz",
@@ -5047,12 +7435,18 @@
     "ncname": {
       "version": "https://registry.npmjs.org/ncname/-/ncname-1.0.0.tgz",
       "integrity": "sha1-W1etGLHKCShk72Kwse2BlPODtxw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "xml-char-classes": "https://registry.npmjs.org/xml-char-classes/-/xml-char-classes-1.0.0.tgz"
+      }
     },
     "neatequal": {
       "version": "https://registry.npmjs.org/neatequal/-/neatequal-1.0.0.tgz",
       "integrity": "sha1-LuEhG8n6bkxVcV/SELsFYC6xrjs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "varstream": "https://registry.npmjs.org/varstream/-/varstream-0.3.2.tgz"
+      }
     },
     "negotiator": {
       "version": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
@@ -5062,21 +7456,80 @@
     "no-case": {
       "version": "https://registry.npmjs.org/no-case/-/no-case-2.3.1.tgz",
       "integrity": "sha1-euuhxzpSGEJlVUt9wDuvcg34AIE=",
+      "dev": true,
+      "requires": {
+        "lower-case": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz"
+      }
+    },
+    "no-scroll": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/no-scroll/-/no-scroll-2.1.0.tgz",
+      "integrity": "sha1-+GQ7PdtqO/lEMOX/MdJvIdCCppU=",
+      "dev": true
+    },
+    "node-dir": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.8.tgz",
+      "integrity": "sha1-VfuN62mQcHB/tn+RpGDwRIKUx30=",
       "dev": true
     },
     "node-fetch": {
       "version": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.1.tgz",
-      "integrity": "sha1-iZyz0KPJL5UsR/G4dvTIrqvUANU="
+      "integrity": "sha1-iZyz0KPJL5UsR/G4dvTIrqvUANU=",
+      "requires": {
+        "encoding": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+        "is-stream": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
+      }
     },
     "node-gyp": {
       "version": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
       "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fstream": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "nopt": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+        "npmlog": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+        "osenv": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+        "request": "https://registry.npmjs.org/request/-/request-2.78.0.tgz",
+        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+        "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+        "tar": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+        "which": "https://registry.npmjs.org/which/-/which-1.2.14.tgz"
+      }
     },
     "node-libs-browser": {
       "version": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.0.0.tgz",
       "integrity": "sha1-o6WeyXAkmFtG6Vg3lkb5bEthZkY=",
       "dev": true,
+      "requires": {
+        "assert": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
+        "browserify-zlib": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+        "buffer": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+        "console-browserify": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+        "constants-browserify": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+        "crypto-browserify": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.0.tgz",
+        "domain-browser": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
+        "events": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+        "https-browserify": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
+        "os-browserify": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.2.1.tgz",
+        "path-browserify": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+        "process": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+        "punycode": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+        "querystring-es3": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+        "stream-browserify": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+        "stream-http": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
+        "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+        "timers-browserify": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.2.tgz",
+        "tty-browserify": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+        "url": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+        "util": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+        "vm-browserify": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz"
+      },
       "dependencies": {
         "string_decoder": {
           "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
@@ -5088,7 +7541,13 @@
     "node-notifier": {
       "version": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.1.2.tgz",
       "integrity": "sha1-L6nhJgX6EACdRFSdb82KY93g5P8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "growly": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+        "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+        "shellwords": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.0.tgz",
+        "which": "https://registry.npmjs.org/which/-/which-1.2.14.tgz"
+      }
     },
     "node-uuid": {
       "version": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
@@ -5098,22 +7557,47 @@
     "node.extend": {
       "version": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.6.tgz",
       "integrity": "sha1-p7iCyC1sk6SGOlUEvV3o7IYli5Y=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is": "https://registry.npmjs.org/is/-/is-3.2.1.tgz"
+      }
+    },
+    "nomnom": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
+      "integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
+      "dev": true,
+      "requires": {
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "underscore": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
+      }
     },
     "nopt": {
       "version": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "abbrev": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz"
+      }
     },
     "normalize-package-data": {
       "version": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+        "is-builtin-module": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+        "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+        "validate-npm-package-license": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
+      }
     },
     "normalize-path": {
       "version": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "remove-trailing-separator": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz"
+      }
     },
     "normalize-range": {
       "version": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
@@ -5123,26 +7607,55 @@
     "normalize-url": {
       "version": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
       "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "prepend-http": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+        "query-string": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
+        "sort-keys": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz"
+      }
     },
     "npm-path": {
       "version": "https://registry.npmjs.org/npm-path/-/npm-path-2.0.3.tgz",
       "integrity": "sha1-Fc/04ciaONp39W9gVbJPl137K74=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "which": "https://registry.npmjs.org/which/-/which-1.2.14.tgz"
+      }
     },
     "npm-which": {
       "version": "https://registry.npmjs.org/npm-which/-/npm-which-3.0.1.tgz",
       "integrity": "sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "commander": "https://registry.npmjs.org/commander/-/commander-2.10.0.tgz",
+        "npm-path": "https://registry.npmjs.org/npm-path/-/npm-path-2.0.3.tgz",
+        "which": "https://registry.npmjs.org/which/-/which-1.2.14.tgz"
+      }
     },
     "npmlog": {
       "version": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha1-CKfyqL9zRgR3mp76StXMcXq7lUs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "are-we-there-yet": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+        "console-control-strings": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+        "gauge": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+        "set-blocking": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
+      }
     },
     "nth-check": {
       "version": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
       "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
+      "dev": true,
+      "requires": {
+        "boolbase": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz"
+      }
+    },
+    "null-check": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/null-check/-/null-check-1.0.0.tgz",
+      "integrity": "sha1-l33/1xdgErnsMNKjnbXPcqBDnt0=",
       "dev": true
     },
     "num2fraction": {
@@ -5153,6 +7666,12 @@
     "number-is-nan": {
       "version": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+    },
+    "numeral": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/numeral/-/numeral-2.0.6.tgz",
+      "integrity": "sha1-StCAk21EPCVhrtnyGX7//iX05QY=",
+      "dev": true
     },
     "nwmatcher": {
       "version": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.1.tgz",
@@ -5191,17 +7710,31 @@
     "object.assign": {
       "version": "https://registry.npmjs.org/object.assign/-/object.assign-4.0.4.tgz",
       "integrity": "sha1-scnMBE7xuf5jYG/BQau7MuFHMMw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "define-properties": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+        "function-bind": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
+        "object-keys": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz"
+      }
     },
     "object.defaults": {
       "version": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
       "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
       "dev": true,
+      "requires": {
+        "array-each": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
+        "array-slice": "https://registry.npmjs.org/array-slice/-/array-slice-1.0.0.tgz",
+        "for-own": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+        "isobject": "https://registry.npmjs.org/isobject/-/isobject-3.0.0.tgz"
+      },
       "dependencies": {
         "for-own": {
           "version": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
           "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "for-in": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz"
+          }
         },
         "isobject": {
           "version": "https://registry.npmjs.org/isobject/-/isobject-3.0.0.tgz",
@@ -5213,22 +7746,35 @@
     "object.omit": {
       "version": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "for-own": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+        "is-extendable": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
+      }
     },
     "object.pick": {
       "version": "https://registry.npmjs.org/object.pick/-/object.pick-1.2.0.tgz",
       "integrity": "sha1-tTkr7peC2m2ft9avr1OXefEjTCs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz"
+      }
     },
     "on-finished": {
       "version": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ee-first": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
+      }
     },
     "once": {
       "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+      }
     },
     "onetime": {
       "version": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
@@ -5243,12 +7789,20 @@
     "opn": {
       "version": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
       "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+      }
     },
     "optimist": {
       "version": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
+      "requires": {
+        "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+        "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+      },
       "dependencies": {
         "wordwrap": {
           "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
@@ -5260,7 +7814,15 @@
     "optionator": {
       "version": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "deep-is": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+        "fast-levenshtein": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+        "levn": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+        "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+        "type-check": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+        "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
+      }
     },
     "options": {
       "version": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
@@ -5270,7 +7832,12 @@
     "orchestrator": {
       "version": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.8.tgz",
       "integrity": "sha1-FOfp4nZPcxX7rBhOUGx6pt+UrX4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "end-of-stream": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
+        "sequencify": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
+        "stream-consume": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz"
+      }
     },
     "ordered-read-streams": {
       "version": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
@@ -5289,7 +7856,10 @@
     },
     "os-locale": {
       "version": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk="
+      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "requires": {
+        "lcid": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz"
+      }
     },
     "os-tmpdir": {
       "version": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
@@ -5299,12 +7869,25 @@
     "osenv": {
       "version": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
       "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+        "os-tmpdir": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
+      }
     },
     "package": {
       "version": "https://registry.npmjs.org/package/-/package-1.0.1.tgz",
       "integrity": "sha1-0lofmeJQbcsn1nBLg9yooxLk7cw=",
       "dev": true
+    },
+    "pad-right": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/pad-right/-/pad-right-0.2.2.tgz",
+      "integrity": "sha1-b7ySQEXSRPKiokRQMGDTv8YAl3Q=",
+      "dev": true,
+      "requires": {
+        "repeat-string": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+      }
     },
     "pako": {
       "version": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
@@ -5314,27 +7897,57 @@
     "param-case": {
       "version": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
       "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "no-case": "https://registry.npmjs.org/no-case/-/no-case-2.3.1.tgz"
+      }
     },
     "parse-asn1": {
       "version": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
       "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "asn1.js": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
+        "browserify-aes": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
+        "create-hash": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
+        "evp_bytestokey": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz",
+        "pbkdf2": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.12.tgz"
+      }
     },
     "parse-filepath": {
       "version": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.1.tgz",
       "integrity": "sha1-FZ1hVdQ5BNFsEO9piRHaHpGWm3M=",
+      "dev": true,
+      "requires": {
+        "is-absolute": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz",
+        "map-cache": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+        "path-root": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz"
+      }
+    },
+    "parse-github-repo-url": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.4.1.tgz",
+      "integrity": "sha1-nn2LslKmy2ukJZUGC3v23z28H1A=",
       "dev": true
     },
     "parse-glob": {
       "version": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glob-base": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+        "is-dotfile": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+        "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+        "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
+      }
     },
     "parse-json": {
       "version": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "error-ex": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz"
+      }
     },
     "parse-passwd": {
       "version": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
@@ -5349,17 +7962,26 @@
     "parsejson": {
       "version": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.3.tgz",
       "integrity": "sha1-q343WfIJ7OmUN5c/fQ8fZK4OZKs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "better-assert": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz"
+      }
     },
     "parseqs": {
       "version": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
       "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "better-assert": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz"
+      }
     },
     "parseuri": {
       "version": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
       "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "better-assert": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz"
+      }
     },
     "parseurl": {
       "version": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
@@ -5379,7 +8001,10 @@
     "path-exists": {
       "version": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+      }
     },
     "path-is-absolute": {
       "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -5399,7 +8024,10 @@
     "path-root": {
       "version": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
       "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "path-root-regex": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz"
+      }
     },
     "path-root-regex": {
       "version": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
@@ -5409,12 +8037,24 @@
     "path-type": {
       "version": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+      }
     },
     "pbkdf2": {
       "version": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.12.tgz",
       "integrity": "sha1-vjZ4XFBn6kjYBv+SMojF91C2uKI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "create-hash": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
+        "create-hmac": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
+        "ripemd160": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
+        "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+        "sha.js": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz"
+      }
     },
     "pbkdf2-compat": {
       "version": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz",
@@ -5439,32 +8079,56 @@
     "pinkie-promise": {
       "version": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pinkie": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+      }
     },
     "pkg-dir": {
       "version": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
       "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "find-up": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz"
+      }
     },
     "pkg-up": {
       "version": "https://registry.npmjs.org/pkg-up/-/pkg-up-1.0.0.tgz",
       "integrity": "sha1-Pgj7RhUlxEIWJKM7n35tCvWwWiY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "find-up": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz"
+      }
     },
     "plexer": {
       "version": "https://registry.npmjs.org/plexer/-/plexer-1.0.1.tgz",
       "integrity": "sha1-qAG2Ur+BRXOXlepNO/CvlGwwwN0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "isstream": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz"
+      }
     },
     "plugin-error": {
       "version": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
       "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
       "dev": true,
+      "requires": {
+        "ansi-cyan": "https://registry.npmjs.org/ansi-cyan/-/ansi-cyan-0.1.1.tgz",
+        "ansi-red": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
+        "arr-diff": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
+        "arr-union": "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz",
+        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz"
+      },
       "dependencies": {
         "arr-diff": {
           "version": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
           "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
+            "array-slice": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz"
+          }
         },
         "array-slice": {
           "version": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
@@ -5477,11 +8141,19 @@
       "version": "https://registry.npmjs.org/plugin-log/-/plugin-log-0.1.0.tgz",
       "integrity": "sha1-hgSc9qsQgzOYqTHzaJy67nteEzM=",
       "dev": true,
+      "requires": {
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "dateformat": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz"
+      },
       "dependencies": {
         "dateformat": {
           "version": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
           "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "get-stdin": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+            "meow": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz"
+          }
         }
       }
     },
@@ -5493,99 +8165,183 @@
     "portscanner": {
       "version": "https://registry.npmjs.org/portscanner/-/portscanner-2.1.1.tgz",
       "integrity": "sha1-6rtAnk3iSVD1oqUW01rnaTQ/u5Y=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+        "is-number-like": "https://registry.npmjs.org/is-number-like/-/is-number-like-1.0.8.tgz"
+      }
     },
     "postcss": {
       "version": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz",
       "integrity": "sha1-cysxAAAPn/g3mkilODntCXN2rVc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "js-base64": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+        "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
+      }
     },
     "postcss-calc": {
       "version": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
       "integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz",
+        "postcss-message-helpers": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
+        "reduce-css-calc": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz"
+      }
     },
     "postcss-colormin": {
       "version": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
       "integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "colormin": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz",
+        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
+      }
     },
     "postcss-convert-values": {
       "version": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz",
       "integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz",
+        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
+      }
     },
     "postcss-discard-comments": {
       "version": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
       "integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz"
+      }
     },
     "postcss-discard-duplicates": {
       "version": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz",
       "integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz"
+      }
     },
     "postcss-discard-empty": {
       "version": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
       "integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz"
+      }
     },
     "postcss-discard-overridden": {
       "version": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
       "integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz"
+      }
     },
     "postcss-discard-unused": {
       "version": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
       "integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz",
+        "uniqs": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
+      }
     },
     "postcss-filter-plugins": {
       "version": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz",
       "integrity": "sha1-bYWGJTTXNaxCDkqFgG4fXUKG2Ew=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz",
+        "uniqid": "https://registry.npmjs.org/uniqid/-/uniqid-4.1.1.tgz"
+      }
     },
     "postcss-load-config": {
       "version": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-1.2.0.tgz",
       "integrity": "sha1-U56a/J3chiASHr+djDZz4M5Q0oo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "cosmiconfig": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.1.3.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "postcss-load-options": "https://registry.npmjs.org/postcss-load-options/-/postcss-load-options-1.2.0.tgz",
+        "postcss-load-plugins": "https://registry.npmjs.org/postcss-load-plugins/-/postcss-load-plugins-2.3.0.tgz"
+      }
     },
     "postcss-load-options": {
       "version": "https://registry.npmjs.org/postcss-load-options/-/postcss-load-options-1.2.0.tgz",
       "integrity": "sha1-sJixVZ3awt8EvAuzdfmaXP4rbYw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "cosmiconfig": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.1.3.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+      }
     },
     "postcss-load-plugins": {
       "version": "https://registry.npmjs.org/postcss-load-plugins/-/postcss-load-plugins-2.3.0.tgz",
       "integrity": "sha1-dFdoEWWZrKLwCfrUJrABdQSdjZI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "cosmiconfig": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.1.3.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+      }
     },
     "postcss-loader": {
       "version": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-1.3.3.tgz",
       "integrity": "sha1-piHqH6KQYqg5cqRvVEhncTAZFus=",
       "dev": true,
+      "requires": {
+        "loader-utils": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz",
+        "postcss-load-config": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-1.2.0.tgz"
+      },
       "dependencies": {
         "loader-utils": {
           "version": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "big.js": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
+            "emojis-list": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+            "json5": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
+          }
         }
       }
     },
     "postcss-merge-idents": {
       "version": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
       "integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "has": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz",
+        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
+      }
     },
     "postcss-merge-longhand": {
       "version": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz",
       "integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz"
+      }
     },
     "postcss-merge-rules": {
       "version": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
       "integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "browserslist": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+        "caniuse-api": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz",
+        "postcss-selector-parser": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
+        "vendors": "https://registry.npmjs.org/vendors/-/vendors-1.0.1.tgz"
+      }
     },
     "postcss-message-helpers": {
       "version": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
@@ -5595,27 +8351,51 @@
     "postcss-minify-font-values": {
       "version": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
       "integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz",
+        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
+      }
     },
     "postcss-minify-gradients": {
       "version": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
       "integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz",
+        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
+      }
     },
     "postcss-minify-params": {
       "version": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
       "integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "alphanum-sort": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz",
+        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
+        "uniqs": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
+      }
     },
     "postcss-minify-selectors": {
       "version": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
       "integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "alphanum-sort": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
+        "has": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz",
+        "postcss-selector-parser": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz"
+      }
     },
     "postcss-modules-extract-imports": {
       "version": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.1.0.tgz",
       "integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
       "dev": true,
+      "requires": {
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-6.0.3.tgz"
+      },
       "dependencies": {
         "has-flag": {
           "version": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
@@ -5625,12 +8405,20 @@
         "postcss": {
           "version": "https://registry.npmjs.org/postcss/-/postcss-6.0.3.tgz",
           "integrity": "sha1-t/Vls9lW+7hWXKfB4jnQUG5CfYs=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-4.0.0.tgz"
+          }
         },
         "supports-color": {
           "version": "https://registry.npmjs.org/supports-color/-/supports-color-4.0.0.tgz",
           "integrity": "sha1-M6fGgKpRLJ0D75KcrLuXTSA9J5A=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz"
+          }
         }
       }
     },
@@ -5638,6 +8426,10 @@
       "version": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
       "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
       "dev": true,
+      "requires": {
+        "css-selector-tokenizer": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-6.0.3.tgz"
+      },
       "dependencies": {
         "has-flag": {
           "version": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
@@ -5647,12 +8439,20 @@
         "postcss": {
           "version": "https://registry.npmjs.org/postcss/-/postcss-6.0.3.tgz",
           "integrity": "sha1-t/Vls9lW+7hWXKfB4jnQUG5CfYs=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-4.0.0.tgz"
+          }
         },
         "supports-color": {
           "version": "https://registry.npmjs.org/supports-color/-/supports-color-4.0.0.tgz",
           "integrity": "sha1-M6fGgKpRLJ0D75KcrLuXTSA9J5A=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz"
+          }
         }
       }
     },
@@ -5660,6 +8460,10 @@
       "version": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
       "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
       "dev": true,
+      "requires": {
+        "css-selector-tokenizer": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-6.0.3.tgz"
+      },
       "dependencies": {
         "has-flag": {
           "version": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
@@ -5669,12 +8473,20 @@
         "postcss": {
           "version": "https://registry.npmjs.org/postcss/-/postcss-6.0.3.tgz",
           "integrity": "sha1-t/Vls9lW+7hWXKfB4jnQUG5CfYs=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-4.0.0.tgz"
+          }
         },
         "supports-color": {
           "version": "https://registry.npmjs.org/supports-color/-/supports-color-4.0.0.tgz",
           "integrity": "sha1-M6fGgKpRLJ0D75KcrLuXTSA9J5A=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz"
+          }
         }
       }
     },
@@ -5682,6 +8494,10 @@
       "version": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
       "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
       "dev": true,
+      "requires": {
+        "icss-replace-symbols": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-6.0.3.tgz"
+      },
       "dependencies": {
         "has-flag": {
           "version": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
@@ -5691,59 +8507,108 @@
         "postcss": {
           "version": "https://registry.npmjs.org/postcss/-/postcss-6.0.3.tgz",
           "integrity": "sha1-t/Vls9lW+7hWXKfB4jnQUG5CfYs=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-4.0.0.tgz"
+          }
         },
         "supports-color": {
           "version": "https://registry.npmjs.org/supports-color/-/supports-color-4.0.0.tgz",
           "integrity": "sha1-M6fGgKpRLJ0D75KcrLuXTSA9J5A=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz"
+          }
         }
       }
     },
     "postcss-normalize-charset": {
       "version": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
       "integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz"
+      }
     },
     "postcss-normalize-url": {
       "version": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
       "integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-absolute-url": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
+        "normalize-url": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz",
+        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
+      }
     },
     "postcss-ordered-values": {
       "version": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz",
       "integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz",
+        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
+      }
     },
     "postcss-reduce-idents": {
       "version": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
       "integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz",
+        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
+      }
     },
     "postcss-reduce-initial": {
       "version": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
       "integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz"
+      }
     },
     "postcss-reduce-transforms": {
       "version": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
       "integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "has": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz",
+        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
+      }
     },
     "postcss-selector-parser": {
       "version": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
       "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "flatten": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
+        "indexes-of": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+        "uniq": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz"
+      }
     },
     "postcss-svgo": {
       "version": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
       "integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-svg": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz",
+        "postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
+        "svgo": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz"
+      }
     },
     "postcss-unique-selectors": {
       "version": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
       "integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "alphanum-sort": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz",
+        "uniqs": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
+      }
     },
     "postcss-value-parser": {
       "version": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
@@ -5753,7 +8618,12 @@
     "postcss-zindex": {
       "version": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
       "integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "has": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz",
+        "uniqs": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
+      }
     },
     "prelude-ls": {
       "version": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -5773,12 +8643,25 @@
     "pretty-error": {
       "version": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.1.tgz",
       "integrity": "sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "renderkid": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.1.tgz",
+        "utila": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz"
+      }
     },
     "pretty-hrtime": {
       "version": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
       "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
       "dev": true
+    },
+    "prismjs": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.8.1.tgz",
+      "integrity": "sha1-vQzcMumlYcHIw8lzN2Wn8ew7VO4=",
+      "dev": true,
+      "requires": {
+        "clipboard": "1.7.1"
+      }
     },
     "private": {
       "version": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
@@ -5802,11 +8685,18 @@
     },
     "promise": {
       "version": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078="
+      "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
+      "requires": {
+        "asap": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz"
+      }
     },
     "prop-types": {
       "version": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz",
-      "integrity": "sha1-J5ffwxJhguOpXj37suiT3ddFYVQ="
+      "integrity": "sha1-J5ffwxJhguOpXj37suiT3ddFYVQ=",
+      "requires": {
+        "fbjs": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz",
+        "loose-envify": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz"
+      }
     },
     "proto-list": {
       "version": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
@@ -5826,7 +8716,14 @@
     "public-encrypt": {
       "version": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
       "integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "bn.js": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.7.tgz",
+        "browserify-rsa": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+        "create-hash": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
+        "parse-asn1": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
+        "randombytes": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz"
+      }
     },
     "punycode": {
       "version": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
@@ -5845,7 +8742,11 @@
     "query-string": {
       "version": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
       "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "strict-uri-encode": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz"
+      }
     },
     "querystring": {
       "version": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
@@ -5866,30 +8767,46 @@
       "version": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
       "integrity": "sha1-x6vpzIuHwLqodrGf3oP9RkeX44w=",
       "dev": true,
+      "requires": {
+        "is-number": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz"
+      },
       "dependencies": {
         "is-number": {
           "version": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
+          "requires": {
+            "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
+          },
           "dependencies": {
             "kind-of": {
               "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+              }
             }
           }
         },
         "kind-of": {
           "version": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+          }
         }
       }
     },
     "randombytes": {
       "version": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
       "integrity": "sha1-3ACaJGuNCaF3tLegrne8Vw9LG3k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+      }
     },
     "range-parser": {
       "version": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
@@ -5899,7 +8816,14 @@
     "react": {
       "version": "https://registry.npmjs.org/react/-/react-15.6.1.tgz",
       "integrity": "sha1-uqhDTsZ4C96ZfNw4C3nNM7ljk98=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "create-react-class": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.0.tgz",
+        "fbjs": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz",
+        "loose-envify": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "prop-types": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz"
+      }
     },
     "react-addons-test-utils": {
       "version": "https://registry.npmjs.org/react-addons-test-utils/-/react-addons-test-utils-15.6.0.tgz",
@@ -5909,59 +8833,139 @@
     "react-dom": {
       "version": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.1.tgz",
       "integrity": "sha1-LLDtQZEDjlPCCes6eaI+Kkz5lHA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fbjs": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz",
+        "loose-envify": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "prop-types": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz"
+      }
+    },
+    "react-live": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/react-live/-/react-live-1.7.1.tgz",
+      "integrity": "sha512-FCZvQXbSG7QlfEPYU5qvcBKymGLCvL90Gd8dQhSq8bixHNX+xM173btgHu7y3U7pDKIVF/0u8B3ZiYBDCkoj2Q==",
+      "dev": true,
+      "requires": {
+        "buble": "0.15.2",
+        "core-js": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+        "dom-iterator": "0.3.0",
+        "prismjs": "1.8.1",
+        "prop-types": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz",
+        "unescape": "0.2.0"
+      }
     },
     "read-pkg": {
       "version": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "load-json-file": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+        "normalize-package-data": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+        "path-type": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz"
+      }
     },
     "read-pkg-up": {
       "version": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "find-up": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+        "read-pkg": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz"
+      }
     },
     "readable-stream": {
       "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
       "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+        "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+        "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+        "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+        "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+      }
     },
     "readdirp": {
       "version": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+        "set-immediate-shim": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
+      }
     },
     "readline2": {
       "version": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
       "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "code-point-at": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+        "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+        "mute-stream": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
+      }
+    },
+    "recast": {
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.12.7.tgz",
+      "integrity": "sha512-UgJBjELa0DaLUbblnIOPUj0UgdbetzYzrvWtHCXX8N5aCTHoMSx6ATkA2JH0hS7tP6dMJ5/CtVZEC4yW7V/8Dw==",
+      "dev": true,
+      "requires": {
+        "ast-types": "0.9.12",
+        "core-js": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+        "esprima": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+        "private": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+      }
     },
     "rechoir": {
       "version": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz"
+      }
     },
     "recursive-readdir": {
       "version": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.1.tgz",
       "integrity": "sha1-kO8jHQd4xc4JPJpI105cVCLROpk=",
       "dev": true,
+      "requires": {
+        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
+      },
       "dependencies": {
         "minimatch": {
           "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
           "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz"
+          }
         }
       }
     },
     "redent": {
       "version": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "indent-string": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+        "strip-indent": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
+      }
     },
     "reduce-css-calc": {
       "version": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
       "integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
       "dev": true,
+      "requires": {
+        "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+        "math-expression-evaluator": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
+        "reduce-function-call": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz"
+      },
       "dependencies": {
         "balanced-match": {
           "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
@@ -5974,6 +8978,9 @@
       "version": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz",
       "integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
       "dev": true,
+      "requires": {
+        "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
+      },
       "dependencies": {
         "balanced-match": {
           "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
@@ -5995,17 +9002,31 @@
     "regenerator-transform": {
       "version": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
       "integrity": "sha1-On0GdSDLe3F2dp61/4aGkb7+EoM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+        "private": "https://registry.npmjs.org/private/-/private-0.1.7.tgz"
+      }
     },
     "regex-cache": {
       "version": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
       "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-equal-shallow": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+        "is-primitive": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+      }
     },
     "regexpu-core": {
       "version": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "regenerate": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
+        "regjsgen": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+        "regjsparser": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz"
+      }
     },
     "regjsgen": {
       "version": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
@@ -6016,6 +9037,9 @@
       "version": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "dev": true,
+      "requires": {
+        "jsesc": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
+      },
       "dependencies": {
         "jsesc": {
           "version": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
@@ -6038,21 +9062,40 @@
       "version": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.1.tgz",
       "integrity": "sha1-iYyr/Ivt5Le5ETWj/9Mj5YwNsxk=",
       "dev": true,
+      "requires": {
+        "css-select": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+        "dom-converter": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.1.4.tgz",
+        "htmlparser2": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.3.0.tgz",
+        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+        "utila": "https://registry.npmjs.org/utila/-/utila-0.3.3.tgz"
+      },
       "dependencies": {
         "domhandler": {
           "version": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz",
           "integrity": "sha1-0mRvXlf2w7qxHPbLBdPArPdBJZQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "domelementtype": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
+          }
         },
         "domutils": {
           "version": "https://registry.npmjs.org/domutils/-/domutils-1.1.6.tgz",
           "integrity": "sha1-vdw94Jm5ou+sxRxiPyj0FuzFdIU=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "domelementtype": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
+          }
         },
         "htmlparser2": {
           "version": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.3.0.tgz",
           "integrity": "sha1-zHDQWln2VC5D8OaFyYLhTJJKnv4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "domelementtype": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+            "domhandler": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz",
+            "domutils": "https://registry.npmjs.org/domutils/-/domutils-1.1.6.tgz",
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
+          }
         },
         "isarray": {
           "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -6062,7 +9105,13 @@
         "readable-stream": {
           "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+          }
         },
         "string_decoder": {
           "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
@@ -6089,7 +9138,10 @@
     "repeating": {
       "version": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-finite": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz"
+      }
     },
     "replace-ext": {
       "version": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
@@ -6100,6 +9152,28 @@
       "version": "https://registry.npmjs.org/request/-/request-2.78.0.tgz",
       "integrity": "sha1-4cjew0bhyBkjskrNszfxHeyr6cw=",
       "dev": true,
+      "requires": {
+        "aws-sign2": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+        "aws4": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+        "caseless": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+        "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+        "extend": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+        "forever-agent": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+        "form-data": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+        "har-validator": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+        "hawk": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+        "http-signature": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+        "is-typedarray": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+        "isstream": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+        "json-stringify-safe": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+        "node-uuid": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+        "oauth-sign": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+        "qs": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
+        "stringstream": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+        "tough-cookie": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+        "tunnel-agent": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
+      },
       "dependencies": {
         "qs": {
           "version": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
@@ -6131,7 +9205,11 @@
     "require-uncached": {
       "version": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "caller-path": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+        "resolve-from": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz"
+      }
     },
     "requires-port": {
       "version": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -6141,12 +9219,19 @@
     "resolve": {
       "version": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
       "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "path-parse": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz"
+      }
     },
     "resolve-dir": {
       "version": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
       "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "expand-tilde": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+        "global-modules": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz"
+      }
     },
     "resolve-from": {
       "version": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
@@ -6156,37 +9241,68 @@
     "resp-modifier": {
       "version": "https://registry.npmjs.org/resp-modifier/-/resp-modifier-6.0.2.tgz",
       "integrity": "sha1-sSTeXE+6/LpUH0j/pzlw9KpFa08=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz"
+      }
     },
     "restore-cursor": {
       "version": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "exit-hook": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+        "onetime": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz"
+      }
     },
     "right-align": {
       "version": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+      "dev": true,
+      "requires": {
+        "align-text": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz"
+      }
+    },
+    "right-pad": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/right-pad/-/right-pad-1.0.1.tgz",
+      "integrity": "sha1-jKCMLLtbVedNr6lr9/0aJ9VoyNA=",
       "dev": true
     },
     "rimraf": {
       "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
       "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
+      }
     },
     "ripemd160": {
       "version": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
       "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "hash-base": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+      }
     },
     "run-async": {
       "version": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
       "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
+      }
     },
     "run-sequence": {
       "version": "https://registry.npmjs.org/run-sequence/-/run-sequence-1.2.2.tgz",
       "integrity": "sha1-UJWgvr6YczsBQL0I3YDsAw3azes=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz"
+      }
     },
     "rx": {
       "version": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
@@ -6207,6 +9323,13 @@
       "version": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk="
     },
+    "select": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
+      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
+      "dev": true,
+      "optional": true
+    },
     "semver": {
       "version": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
       "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
@@ -6216,11 +9339,29 @@
       "version": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
       "integrity": "sha1-qVSYQyU5L1FTKndgdg5FlZjIn3o=",
       "dev": true,
+      "requires": {
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+        "depd": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+        "destroy": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+        "encodeurl": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
+        "escape-html": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+        "etag": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
+        "fresh": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
+        "http-errors": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
+        "mime": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+        "ms": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+        "on-finished": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+        "range-parser": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+        "statuses": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
+      },
       "dependencies": {
         "debug": {
           "version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+          }
         },
         "etag": {
           "version": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
@@ -6248,11 +9389,23 @@
       "version": "https://registry.npmjs.org/serve-index/-/serve-index-1.8.0.tgz",
       "integrity": "sha1-fF2WwT+xMRAfk8HFd0+FFqHnjTs=",
       "dev": true,
+      "requires": {
+        "accepts": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+        "batch": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+        "escape-html": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+        "http-errors": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
+        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+        "parseurl": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
+      },
       "dependencies": {
         "debug": {
           "version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+          }
         },
         "ms": {
           "version": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
@@ -6264,7 +9417,13 @@
     "serve-static": {
       "version": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz",
       "integrity": "sha1-1sznaTUF9zPHWd5Xvvwa92wPCAU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "encodeurl": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
+        "escape-html": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+        "parseurl": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+        "send": "https://registry.npmjs.org/send/-/send-0.14.1.tgz"
+      }
     },
     "server-destroy": {
       "version": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
@@ -6293,12 +9452,18 @@
     "sha.js": {
       "version": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz",
       "integrity": "sha1-NwaMLEdra69ALRSknGf1l5IfY08=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+      }
     },
     "shebang-command": {
       "version": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "shebang-regex": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
+      }
     },
     "shebang-regex": {
       "version": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
@@ -6308,7 +9473,12 @@
     "shelljs": {
       "version": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
       "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+        "interpret": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
+        "rechoir": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz"
+      }
     },
     "shellwords": {
       "version": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.0.tgz",
@@ -6317,7 +9487,8 @@
     },
     "shortid": {
       "version": "https://registry.npmjs.org/shortid/-/shortid-2.2.8.tgz",
-      "integrity": "sha1-AzsRfWoul1gE9vCWnb59PQs1UTE="
+      "integrity": "sha1-AzsRfWoul1gE9vCWnb59PQs1UTE=",
+      "dev": true
     },
     "sigmund": {
       "version": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
@@ -6339,20 +9510,41 @@
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
       "dev": true
     },
+    "slide": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+      "dev": true
+    },
     "sntp": {
       "version": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+      }
     },
     "socket.io": {
       "version": "https://registry.npmjs.org/socket.io/-/socket.io-1.6.0.tgz",
       "integrity": "sha1-PkDZMmN+a9kjmBslyvfFPoO24uE=",
       "dev": true,
+      "requires": {
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+        "engine.io": "https://registry.npmjs.org/engine.io/-/engine.io-1.8.0.tgz",
+        "has-binary": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+        "socket.io-adapter": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.5.0.tgz",
+        "socket.io-client": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.6.0.tgz",
+        "socket.io-parser": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.3.1.tgz"
+      },
       "dependencies": {
         "debug": {
           "version": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
           "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+          }
         },
         "ms": {
           "version": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
@@ -6370,11 +9562,18 @@
       "version": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.5.0.tgz",
       "integrity": "sha1-y21LuL7IHhB4uZZ3+c7QBGBmu4s=",
       "dev": true,
+      "requires": {
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+        "socket.io-parser": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.3.1.tgz"
+      },
       "dependencies": {
         "debug": {
           "version": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
           "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+          }
         },
         "ms": {
           "version": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
@@ -6387,6 +9586,19 @@
       "version": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.6.0.tgz",
       "integrity": "sha1-W2aPT3cTBN/u0XkGRwg4b6ZxeFM=",
       "dev": true,
+      "requires": {
+        "backo2": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+        "component-bind": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
+        "component-emitter": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+        "engine.io-client": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.8.0.tgz",
+        "has-binary": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
+        "indexof": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+        "object-component": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
+        "parseuri": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
+        "socket.io-parser": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.3.1.tgz",
+        "to-array": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz"
+      },
       "dependencies": {
         "component-emitter": {
           "version": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
@@ -6396,7 +9608,10 @@
         "debug": {
           "version": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
           "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+          }
         },
         "ms": {
           "version": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
@@ -6409,11 +9624,20 @@
       "version": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.3.1.tgz",
       "integrity": "sha1-3VMgJRA85Clpcya+/WQAX8/ltKA=",
       "dev": true,
+      "requires": {
+        "component-emitter": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
+        "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+        "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+        "json3": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz"
+      },
       "dependencies": {
         "debug": {
           "version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+          }
         },
         "isarray": {
           "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -6430,7 +9654,10 @@
     "sort-keys": {
       "version": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
       "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-plain-obj": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz"
+      }
     },
     "source-list-map": {
       "version": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.8.tgz",
@@ -6445,7 +9672,10 @@
     "source-map-support": {
       "version": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
       "integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+      }
     },
     "sparkles": {
       "version": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
@@ -6455,7 +9685,10 @@
     "spdx-correct": {
       "version": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "spdx-license-ids": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
+      }
     },
     "spdx-expression-parse": {
       "version": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
@@ -6467,6 +9700,24 @@
       "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
       "dev": true
     },
+    "split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "dev": true,
+      "requires": {
+        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+      }
+    },
+    "split2": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
+      "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
+      "dev": true,
+      "requires": {
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+      }
+    },
     "sprintf-js": {
       "version": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
@@ -6476,12 +9727,37 @@
       "version": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
       "dev": true,
+      "requires": {
+        "asn1": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+        "bcrypt-pbkdf": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+        "dashdash": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+        "ecc-jsbn": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+        "getpass": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+        "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+        "tweetnacl": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "dev": true
         }
+      }
+    },
+    "standard-version": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/standard-version/-/standard-version-4.2.0.tgz",
+      "integrity": "sha1-MBfoxc7SqS23UBeQJVw7qFFXN10=",
+      "dev": true,
+      "requires": {
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "conventional-changelog": "1.1.6",
+        "conventional-recommended-bump": "1.0.2",
+        "figures": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+        "fs-access": "1.0.1",
+        "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+        "yargs": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz"
       }
     },
     "statuses": {
@@ -6492,7 +9768,11 @@
     "stream-browserify": {
       "version": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
       "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz"
+      }
     },
     "stream-consume": {
       "version": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz",
@@ -6502,7 +9782,14 @@
     "stream-http": {
       "version": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
       "integrity": "sha1-QKBQ7I3DtTsz2ZCUFcAsC/Gr+60=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "builtin-status-codes": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+        "to-arraybuffer": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+        "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+      }
     },
     "stream-shift": {
       "version": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
@@ -6512,12 +9799,19 @@
     "stream-throttle": {
       "version": "https://registry.npmjs.org/stream-throttle/-/stream-throttle-0.1.3.tgz",
       "integrity": "sha1-rdV8jXzHOoFjDTHNVdOWHPr7qcM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "commander": "https://registry.npmjs.org/commander/-/commander-2.10.0.tgz",
+        "limiter": "https://registry.npmjs.org/limiter/-/limiter-1.1.2.tgz"
+      }
     },
     "streamfilter": {
       "version": "https://registry.npmjs.org/streamfilter/-/streamfilter-1.0.5.tgz",
       "integrity": "sha1-h1BxEb644phFFxe1Ec/tjwAqv1M=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz"
+      }
     },
     "strict-uri-encode": {
       "version": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
@@ -6527,11 +9821,19 @@
     "string_decoder": {
       "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
       "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+      }
     },
     "string-width": {
       "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M="
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "requires": {
+        "code-point-at": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+        "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+      }
     },
     "string.fromcodepoint": {
       "version": "https://registry.npmjs.org/string.fromcodepoint/-/string.fromcodepoint-0.2.1.tgz",
@@ -6550,27 +9852,43 @@
     },
     "strip-ansi": {
       "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8="
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "requires": {
+        "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+      }
     },
     "strip-bom": {
       "version": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-utf8": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
+      }
     },
     "strip-bom-buf": {
       "version": "https://registry.npmjs.org/strip-bom-buf/-/strip-bom-buf-1.0.0.tgz",
       "integrity": "sha1-HLRar1dTD0yvhsf3UXnSyaUd1XI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-utf8": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
+      }
     },
     "strip-bom-stream": {
       "version": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
       "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "first-chunk-stream": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
+        "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
+      }
     },
     "strip-indent": {
       "version": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "get-stdin": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+      }
     },
     "strip-json-comments": {
       "version": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
@@ -6581,28 +9899,50 @@
       "version": "https://registry.npmjs.org/style-loader/-/style-loader-0.16.1.tgz",
       "integrity": "sha1-UOMlJY1OeEId2WgGNrQehmFZXRA=",
       "dev": true,
+      "requires": {
+        "loader-utils": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz"
+      },
       "dependencies": {
         "loader-utils": {
           "version": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "big.js": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
+            "emojis-list": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+            "json5": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
+          }
         }
       }
     },
     "supports-color": {
       "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
       "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+      }
     },
     "svg-pathdata": {
       "version": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-1.0.4.tgz",
       "integrity": "sha1-emgTQqrH7/2NUq+6eZmRDJ2juVk=",
       "dev": true,
+      "requires": {
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
+      },
       "dependencies": {
         "readable-stream": {
           "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
           "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+            "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+          }
         },
         "string_decoder": {
           "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
@@ -6613,22 +9953,55 @@
     },
     "svg-to-jsx": {
       "version": "https://registry.npmjs.org/svg-to-jsx/-/svg-to-jsx-0.0.20.tgz",
-      "integrity": "sha1-R/u2clAfJZhwPzyQ7KJuZP0k2CA="
+      "integrity": "sha1-R/u2clAfJZhwPzyQ7KJuZP0k2CA=",
+      "requires": {
+        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "q": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
+        "xml2js": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
+        "xmlbuilder": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.6.5.tgz",
+        "yargs": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz"
+      }
     },
     "svg2ttf": {
       "version": "https://registry.npmjs.org/svg2ttf/-/svg2ttf-4.1.0.tgz",
       "integrity": "sha1-ggIuVovQPBq7Zo/djRXwCJVqDhA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "argparse": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+        "cubic2quad": "https://registry.npmjs.org/cubic2quad/-/cubic2quad-1.1.1.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+        "microbuffer": "https://registry.npmjs.org/microbuffer/-/microbuffer-1.0.0.tgz",
+        "svgpath": "https://registry.npmjs.org/svgpath/-/svgpath-2.2.1.tgz",
+        "xmldom": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz"
+      }
     },
     "svgicons2svgfont": {
       "version": "https://registry.npmjs.org/svgicons2svgfont/-/svgicons2svgfont-5.0.1.tgz",
       "integrity": "sha1-W0v53KmnS1Uob4ty3HrnNvEv4C8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "commander": "https://registry.npmjs.org/commander/-/commander-2.10.0.tgz",
+        "neatequal": "https://registry.npmjs.org/neatequal/-/neatequal-1.0.0.tgz",
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+        "sax": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+        "string.fromcodepoint": "https://registry.npmjs.org/string.fromcodepoint/-/string.fromcodepoint-0.2.1.tgz",
+        "string.prototype.codepointat": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.0.tgz",
+        "svg-pathdata": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-1.0.4.tgz"
+      }
     },
     "svgo": {
       "version": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
       "integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "coa": "https://registry.npmjs.org/coa/-/coa-1.0.3.tgz",
+        "colors": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+        "csso": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
+        "js-yaml": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "sax": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+        "whet.extend": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz"
+      }
     },
     "svgpath": {
       "version": "https://registry.npmjs.org/svgpath/-/svgpath-2.2.1.tgz",
@@ -6644,6 +10017,14 @@
       "version": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "dev": true,
+      "requires": {
+        "ajv": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+        "ajv-keywords": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+        "slice-ansi": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+        "string-width": "https://registry.npmjs.org/string-width/-/string-width-2.1.0.tgz"
+      },
       "dependencies": {
         "ansi-regex": {
           "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -6658,12 +10039,19 @@
         "string-width": {
           "version": "https://registry.npmjs.org/string-width/-/string-width-2.1.0.tgz",
           "integrity": "sha1-AwZkVh/BRslCPsfZeP4kV0N/5tA=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz"
+          }
         },
         "strip-ansi": {
           "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz"
+          }
         }
       }
     },
@@ -6675,11 +10063,35 @@
     "tar": {
       "version": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "block-stream": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+        "fstream": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+      }
+    },
+    "temp": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
+      "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+        "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz"
+      }
     },
     "temporary": {
       "version": "https://registry.npmjs.org/temporary/-/temporary-0.0.8.tgz",
       "integrity": "sha1-oYqYHSi6jKNgJ/s8MFOMPst0CsA=",
+      "dev": true,
+      "requires": {
+        "package": "https://registry.npmjs.org/package/-/package-1.0.1.tgz"
+      }
+    },
+    "text-extensions": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.7.0.tgz",
+      "integrity": "sha512-AKXZeDq230UaSzaO5s3qQUZOaC7iKbzq0jOFL614R7d9R593HLqAOL0cYoqLdkNrjBSOdmoQI06yigq1TSBXAg==",
       "dev": true
     },
     "text-table": {
@@ -6690,7 +10102,11 @@
     "tfunk": {
       "version": "https://registry.npmjs.org/tfunk/-/tfunk-3.1.0.tgz",
       "integrity": "sha1-OORBT8ZJd9h6/apy+sttKfgve1s=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+        "object-path": "https://registry.npmjs.org/object-path/-/object-path-0.9.2.tgz"
+      }
     },
     "through": {
       "version": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -6700,17 +10116,28 @@
     "through2": {
       "version": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+        "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+      }
     },
     "through2-filter": {
       "version": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
       "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+        "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+      }
     },
     "tildify": {
       "version": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
       "integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
+      }
     },
     "time-stamp": {
       "version": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
@@ -6720,17 +10147,39 @@
     "timers-browserify": {
       "version": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.2.tgz",
       "integrity": "sha1-q0iDz1l9zVCvIRNJoA+8pWrIa4Y=",
+      "dev": true,
+      "requires": {
+        "setimmediate": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz"
+      }
+    },
+    "tiny-emitter": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.0.2.tgz",
+      "integrity": "sha512-2NM0auVBGft5tee/OxP4PI3d8WItkDM+fPnaRAVo6xTDI2knbz9eC5ArWGqtGlYqiH3RU5yMpdyTTO7MguC4ow==",
+      "dev": true,
+      "optional": true
+    },
+    "tinycolor2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.1.tgz",
+      "integrity": "sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g=",
       "dev": true
     },
     "to-absolute-glob": {
       "version": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
       "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
       "dev": true,
+      "requires": {
+        "extend-shallow": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz"
+      },
       "dependencies": {
         "extend-shallow": {
           "version": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-extendable": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
+          }
         }
       }
     },
@@ -6757,7 +10206,10 @@
     "tough-cookie": {
       "version": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
       "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "punycode": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+      }
     },
     "tr46": {
       "version": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -6767,6 +10219,12 @@
     "trim-newlines": {
       "version": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
       "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+      "dev": true
+    },
+    "trim-off-newlines": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
+      "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
       "dev": true
     },
     "trim-right": {
@@ -6783,11 +10241,18 @@
       "version": "https://registry.npmjs.org/ttf2eot/-/ttf2eot-1.3.0.tgz",
       "integrity": "sha1-lGcerPpa13mc1vn1tgMPUTsDKsI=",
       "dev": true,
+      "requires": {
+        "argparse": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz"
+      },
       "dependencies": {
         "argparse": {
           "version": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
           "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "underscore": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+            "underscore.string": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
+          }
         }
       }
     },
@@ -6795,18 +10260,32 @@
       "version": "https://registry.npmjs.org/ttf2woff/-/ttf2woff-1.3.0.tgz",
       "integrity": "sha1-dqJ6bzDqA3qe1kyf9D7H7UYebSo=",
       "dev": true,
+      "requires": {
+        "argparse": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+        "pako": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz"
+      },
       "dependencies": {
         "argparse": {
           "version": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
           "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "underscore": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+            "underscore.string": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
+          }
         }
       }
     },
     "ttf2woff2": {
       "version": "https://registry.npmjs.org/ttf2woff2/-/ttf2woff2-2.0.3.tgz",
       "integrity": "sha1-XgIK/m5kMofzrXaHq+0g/mVOsyk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "bindings": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
+        "bufferstreams": "https://registry.npmjs.org/bufferstreams/-/bufferstreams-1.1.1.tgz",
+        "nan": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
+        "node-gyp": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz"
+      }
     },
     "tty-browserify": {
       "version": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
@@ -6827,7 +10306,10 @@
     "type-check": {
       "version": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+      }
     },
     "typedarray": {
       "version": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -6842,11 +10324,18 @@
       "version": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.0.21.tgz",
       "integrity": "sha1-22ZpDHoSmi27JBf4IMoVwRkhWgU=",
       "dev": true,
+      "requires": {
+        "commander": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+      },
       "dependencies": {
         "commander": {
           "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
           "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-readlink": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+          }
         }
       }
     },
@@ -6875,6 +10364,12 @@
       "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs=",
       "dev": true
     },
+    "unescape": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/unescape/-/unescape-0.2.0.tgz",
+      "integrity": "sha1-t4ubYMhvFinfGBv1Pu47yNY2fd8=",
+      "dev": true
+    },
     "uniq": {
       "version": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
       "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
@@ -6883,7 +10378,10 @@
     "uniqid": {
       "version": "https://registry.npmjs.org/uniqid/-/uniqid-4.1.1.tgz",
       "integrity": "sha1-iSIN32t1GuUrX3JISGNShZa7hME=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "macaddress": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.8.tgz"
+      }
     },
     "uniqs": {
       "version": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
@@ -6909,6 +10407,10 @@
       "version": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
       "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
       "dev": true,
+      "requires": {
+        "punycode": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+        "querystring": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
+      },
       "dependencies": {
         "punycode": {
           "version": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
@@ -6920,12 +10422,18 @@
     "user-home": {
       "version": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
       "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
+      }
     },
     "util": {
       "version": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
       "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
       "dev": true,
+      "requires": {
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+      },
       "dependencies": {
         "inherits": {
           "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
@@ -6953,6 +10461,9 @@
       "version": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
       "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
       "dev": true,
+      "requires": {
+        "user-home": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+      },
       "dependencies": {
         "user-home": {
           "version": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
@@ -6969,12 +10480,19 @@
     "validate-npm-package-license": {
       "version": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "spdx-correct": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+        "spdx-expression-parse": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz"
+      }
     },
     "varstream": {
       "version": "https://registry.npmjs.org/varstream/-/varstream-0.3.2.tgz",
       "integrity": "sha1-GKxklHZfP/GjWtmkvgU77BiKXeE=",
       "dev": true,
+      "requires": {
+        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
+      },
       "dependencies": {
         "isarray": {
           "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -6984,7 +10502,13 @@
         "readable-stream": {
           "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+          }
         },
         "string_decoder": {
           "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
@@ -7001,32 +10525,60 @@
     "verror": {
       "version": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
       "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+      }
     },
     "vinyl": {
       "version": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
       "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "clone": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+        "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+        "replace-ext": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+      }
     },
     "vinyl-file": {
       "version": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-2.0.0.tgz",
       "integrity": "sha1-p+v1/779obfRjRQPyweyI++2dRo=",
       "dev": true,
+      "requires": {
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+        "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+        "strip-bom-stream": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-2.0.0.tgz",
+        "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz"
+      },
       "dependencies": {
         "first-chunk-stream": {
           "version": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz",
           "integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz"
+          }
         },
         "strip-bom-stream": {
           "version": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-2.0.0.tgz",
           "integrity": "sha1-+H217yYT9paKpUWr/h7HKLaoKco=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "first-chunk-stream": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz",
+            "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
+          }
         },
         "vinyl": {
           "version": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "clone": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+            "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+            "replace-ext": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+          }
         }
       }
     },
@@ -7034,6 +10586,16 @@
       "version": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
       "integrity": "sha1-mmhRzhysHBzqX+hsCTHWIMLPqeY=",
       "dev": true,
+      "requires": {
+        "defaults": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+        "glob-stream": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
+        "glob-watcher": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
+        "through2": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+        "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz"
+      },
       "dependencies": {
         "clone": {
           "version": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
@@ -7043,7 +10605,10 @@
         "graceful-fs": {
           "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
           "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "natives": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz"
+          }
         },
         "isarray": {
           "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -7053,7 +10618,13 @@
         "readable-stream": {
           "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+          }
         },
         "string_decoder": {
           "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
@@ -7063,49 +10634,87 @@
         "strip-bom": {
           "version": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
           "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "first-chunk-stream": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
+            "is-utf8": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
+          }
         },
         "through2": {
           "version": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+            "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+          }
         },
         "vinyl": {
           "version": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "clone": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+            "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+          }
         }
       }
     },
     "vinyl-named": {
       "version": "https://registry.npmjs.org/vinyl-named/-/vinyl-named-1.1.0.tgz",
       "integrity": "sha1-lOT+dB442w7DA+Wz2Giyl6Leq2Y=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+      }
     },
     "vinyl-paths": {
       "version": "https://registry.npmjs.org/vinyl-paths/-/vinyl-paths-2.1.0.tgz",
       "integrity": "sha1-AIIEN8ujgmLO+IAthA+T4zku5Es=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+      }
     },
     "vinyl-sourcemaps-apply": {
       "version": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
       "integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
+      "dev": true,
+      "requires": {
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+      }
+    },
+    "vlq": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
+      "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==",
       "dev": true
     },
     "vm-browserify": {
       "version": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
       "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "indexof": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+      }
     },
     "watchpack": {
       "version": "https://registry.npmjs.org/watchpack/-/watchpack-1.3.1.tgz",
       "integrity": "sha1-fYaTkHsozmAT5/NhCqKhrPB9rYc=",
       "dev": true,
+      "requires": {
+        "async": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
+        "chokidar": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.1.tgz",
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+      },
       "dependencies": {
         "async": {
           "version": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
           "integrity": "sha1-hDGQ/WtzV6C54clW7d3V7IRitU0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+          }
         }
       }
     },
@@ -7118,6 +10727,28 @@
       "version": "https://registry.npmjs.org/webpack/-/webpack-2.3.3.tgz",
       "integrity": "sha1-7swIPBj7e/lY6k9AtXpmQMWgzHg=",
       "dev": true,
+      "requires": {
+        "acorn": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+        "acorn-dynamic-import": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
+        "ajv": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+        "ajv-keywords": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+        "async": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
+        "enhanced-resolve": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.1.0.tgz",
+        "interpret": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
+        "json-loader": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.4.tgz",
+        "loader-runner": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.0.tgz",
+        "loader-utils": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+        "memory-fs": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+        "node-libs-browser": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.0.0.tgz",
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+        "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+        "tapable": "https://registry.npmjs.org/tapable/-/tapable-0.2.6.tgz",
+        "uglify-js": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+        "watchpack": "https://registry.npmjs.org/watchpack/-/watchpack-1.3.1.tgz",
+        "webpack-sources": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.2.3.tgz",
+        "yargs": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz"
+      },
       "dependencies": {
         "acorn": {
           "version": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
@@ -7127,7 +10758,10 @@
         "async": {
           "version": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
           "integrity": "sha1-hDGQ/WtzV6C54clW7d3V7IRitU0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+          }
         },
         "camelcase": {
           "version": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
@@ -7137,7 +10771,12 @@
         "cliui": {
           "version": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
           "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "center-align": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+            "right-align": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+            "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+          }
         },
         "source-list-map": {
           "version": "https://registry.npmjs.org/source-list-map/-/source-list-map-1.1.2.tgz",
@@ -7148,18 +10787,33 @@
           "version": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
           "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
           "dev": true,
+          "requires": {
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+            "uglify-to-browserify": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+            "yargs": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
+          },
           "dependencies": {
             "yargs": {
               "version": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
               "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                "cliui": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                "window-size": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+              }
             }
           }
         },
         "webpack-sources": {
           "version": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.2.3.tgz",
           "integrity": "sha1-F8Yr+vE8cH+dAsR54Nzd6DgGl/s=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "source-list-map": "https://registry.npmjs.org/source-list-map/-/source-list-map-1.1.2.tgz",
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+          }
         },
         "window-size": {
           "version": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
@@ -7175,6 +10829,21 @@
           "version": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
           "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
           "dev": true,
+          "requires": {
+            "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+            "cliui": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+            "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "get-caller-file": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+            "os-locale": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+            "read-pkg-up": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+            "require-directory": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "require-main-filename": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+            "set-blocking": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+            "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "which-module": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+            "y18n": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+            "yargs-parser": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz"
+          },
           "dependencies": {
             "camelcase": {
               "version": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
@@ -7184,7 +10853,12 @@
             "cliui": {
               "version": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
               "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                "wrap-ansi": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz"
+              }
             }
           }
         }
@@ -7194,23 +10868,43 @@
       "version": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.9.tgz",
       "integrity": "sha1-/FcViMhVjad76e+23r3Fo7FyvcI=",
       "dev": true,
+      "requires": {
+        "source-list-map": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.8.tgz",
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
+      },
       "dependencies": {
         "source-map": {
           "version": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+          }
         }
       }
     },
     "webpack-sources": {
       "version": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.1.5.tgz",
       "integrity": "sha1-qh86vw8NdNtxEcQOUAuE+WZkB1A=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "source-list-map": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.8.tgz",
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+      }
     },
     "webpack-stream": {
       "version": "https://registry.npmjs.org/webpack-stream/-/webpack-stream-3.2.0.tgz",
       "integrity": "sha1-Oh0WD7EdQXJ7fObzL3IkZPmLIYY=",
       "dev": true,
+      "requires": {
+        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+        "lodash.clone": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
+        "lodash.some": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
+        "memory-fs": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz",
+        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+        "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+        "webpack": "https://registry.npmjs.org/webpack/-/webpack-1.15.0.tgz"
+      },
       "dependencies": {
         "acorn": {
           "version": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
@@ -7220,7 +10914,10 @@
         "browserify-aes": {
           "version": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.4.0.tgz",
           "integrity": "sha1-BnFJtmjfMcS1hTPgLQHoBthgjiw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+          }
         },
         "camelcase": {
           "version": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
@@ -7230,17 +10927,33 @@
         "cliui": {
           "version": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
           "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "center-align": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+            "right-align": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+            "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+          }
         },
         "crypto-browserify": {
           "version": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.3.0.tgz",
           "integrity": "sha1-ufx1u0oO1h3PHNXa6W6zDJw+UGw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "browserify-aes": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.4.0.tgz",
+            "pbkdf2-compat": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz",
+            "ripemd160": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz",
+            "sha.js": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz"
+          }
         },
         "enhanced-resolve": {
           "version": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
           "integrity": "sha1-TW5omzcl+GCQknzMhs2fFjW4ni4=",
           "dev": true,
+          "requires": {
+            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+            "memory-fs": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz",
+            "tapable": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz"
+          },
           "dependencies": {
             "memory-fs": {
               "version": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz",
@@ -7257,12 +10970,41 @@
         "memory-fs": {
           "version": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz",
           "integrity": "sha1-e8xrYp46Q+hx1+Kaymrop/FcuyA=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "errno": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz"
+          }
         },
         "node-libs-browser": {
           "version": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.7.0.tgz",
           "integrity": "sha1-PicsCBnjCJNeJmdECNevDhSRuDs=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "assert": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
+            "browserify-zlib": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+            "buffer": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+            "console-browserify": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+            "constants-browserify": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+            "crypto-browserify": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.3.0.tgz",
+            "domain-browser": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
+            "events": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+            "https-browserify": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
+            "os-browserify": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.2.1.tgz",
+            "path-browserify": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+            "process": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+            "punycode": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+            "querystring-es3": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+            "stream-browserify": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+            "stream-http": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
+            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+            "timers-browserify": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.2.tgz",
+            "tty-browserify": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+            "url": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+            "util": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+            "vm-browserify": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz"
+          }
         },
         "ripemd160": {
           "version": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz",
@@ -7288,6 +11030,12 @@
           "version": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.5.tgz",
           "integrity": "sha1-RhLAx7qu4rp8SH3kkErhIgefLKg=",
           "dev": true,
+          "requires": {
+            "async": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+            "uglify-to-browserify": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+            "yargs": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
+          },
           "dependencies": {
             "async": {
               "version": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
@@ -7299,12 +11047,22 @@
         "vinyl": {
           "version": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "clone": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+            "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+            "replace-ext": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+          }
         },
         "watchpack": {
           "version": "https://registry.npmjs.org/watchpack/-/watchpack-0.2.9.tgz",
           "integrity": "sha1-Yuqkq15bo1/fwBgnVibjwPXj+ws=",
           "dev": true,
+          "requires": {
+            "async": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+            "chokidar": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.1.tgz",
+            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+          },
           "dependencies": {
             "async": {
               "version": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
@@ -7316,7 +11074,24 @@
         "webpack": {
           "version": "https://registry.npmjs.org/webpack/-/webpack-1.15.0.tgz",
           "integrity": "sha1-T/MfU9sDM55VFkqdRo7gMklo/pg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "acorn": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+            "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+            "clone": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+            "enhanced-resolve": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
+            "interpret": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz",
+            "loader-utils": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+            "memory-fs": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz",
+            "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "node-libs-browser": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.7.0.tgz",
+            "optimist": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+            "tapable": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz",
+            "uglify-js": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.5.tgz",
+            "watchpack": "https://registry.npmjs.org/watchpack/-/watchpack-0.2.9.tgz",
+            "webpack-core": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.9.tgz"
+          }
         },
         "window-size": {
           "version": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
@@ -7331,19 +11106,33 @@
         "yargs": {
           "version": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+            "cliui": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+            "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "window-size": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+          }
         }
       }
     },
     "weinre": {
       "version": "https://registry.npmjs.org/weinre/-/weinre-2.0.0-pre-I0Z7U9OV.tgz",
       "integrity": "sha1-/viqIjkh97QLu71MPtQwL2/QqBM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "express": "https://registry.npmjs.org/express/-/express-2.5.11.tgz",
+        "nopt": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+        "underscore": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
+      }
     },
     "whatwg-encoding": {
       "version": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.1.tgz",
       "integrity": "sha1-PGxFGhmO567FWx7GHQkgxngBpfQ=",
       "dev": true,
+      "requires": {
+        "iconv-lite": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
+      },
       "dependencies": {
         "iconv-lite": {
           "version": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
@@ -7360,6 +11149,10 @@
       "version": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-4.8.0.tgz",
       "integrity": "sha1-0pgaqRSMHgCkHFphMRZqtGg7vMA=",
       "dev": true,
+      "requires": {
+        "tr46": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+        "webidl-conversions": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz"
+      },
       "dependencies": {
         "webidl-conversions": {
           "version": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -7376,7 +11169,10 @@
     "which": {
       "version": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
       "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "isexe": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
+      }
     },
     "which-module": {
       "version": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
@@ -7386,11 +11182,20 @@
     "wide-align": {
       "version": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
       "integrity": "sha1-Vx4PGwYEY268DfwhsDObvjE0FxA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
+      }
     },
     "window-size": {
       "version": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
       "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
     },
     "wordwrap": {
       "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
@@ -7399,12 +11204,19 @@
     },
     "wrap-ansi": {
       "version": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU="
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "requires": {
+        "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+      }
     },
     "wrap-promise": {
       "version": "https://registry.npmjs.org/wrap-promise/-/wrap-promise-1.0.1.tgz",
       "integrity": "sha1-sBn0I2zL8ftWCSG0tIcLe9ovUlU=",
       "dev": true,
+      "requires": {
+        "es6-promise": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz"
+      },
       "dependencies": {
         "es6-promise": {
           "version": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
@@ -7421,12 +11233,30 @@
     "write": {
       "version": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+      }
+    },
+    "write-file-atomic": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+      "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+        "imurmurhash": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+        "slide": "1.1.6"
+      }
     },
     "ws": {
       "version": "https://registry.npmjs.org/ws/-/ws-1.1.1.tgz",
       "integrity": "sha1-CC3bbGQehdS7RR8D1S8G6r2x8Bg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "options": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+        "ultron": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz"
+      }
     },
     "wtf-8": {
       "version": "https://registry.npmjs.org/wtf-8/-/wtf-8-1.0.0.tgz",
@@ -7446,16 +11276,26 @@
     "xml2js": {
       "version": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
       "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
+      "requires": {
+        "sax": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+        "xmlbuilder": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz"
+      },
       "dependencies": {
         "xmlbuilder": {
           "version": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
-          "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU="
+          "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
+          "requires": {
+            "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+          }
         }
       }
     },
     "xmlbuilder": {
       "version": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.6.5.tgz",
       "integrity": "sha1-b/etYPty0idk8AehZLd/K/FABSY=",
+      "requires": {
+        "lodash": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+      },
       "dependencies": {
         "lodash": {
           "version": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
@@ -7489,12 +11329,24 @@
     },
     "yargs": {
       "version": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
-      "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU="
+      "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+      "requires": {
+        "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+        "cliui": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+        "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+        "os-locale": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+        "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+        "window-size": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+        "y18n": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz"
+      }
     },
     "yargs-parser": {
       "version": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
       "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
       "dev": true,
+      "requires": {
+        "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
+      },
       "dependencies": {
         "camelcase": {
           "version": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -98,8 +98,8 @@
     "webpack-stream": "3.2.0"
   },
   "dependencies": {
+    "nanoid": "^0.2.2",
     "prop-types": "^15.5.8",
-    "shortid": "^2.2.8",
     "svg-to-jsx": "^0.0.20"
   },
   "peerDependencies": {

--- a/src/components/InlineSVG.js
+++ b/src/components/InlineSVG.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import svgtojsx from 'svg-to-jsx';
-import shortid from 'shortid';
+import nanoid from 'nanoid';
 
 export default class InlineSVG extends React.Component {
   static propTypes = {
@@ -19,8 +19,8 @@ export default class InlineSVG extends React.Component {
   constructor (props) {
     super();
 
-    this.titleId = shortid.generate();
-    this.descId = shortid.generate();
+    this.titleId = nanoid(7);
+    this.descId = nanoid(7);
   }
 
   get role () {


### PR DESCRIPTION
Hi. Thanks for an awesome project. I found the way how to make it a little better. By replacing unqiue ID generator from `shortid` to [`nanoid`](https://github.com/ai/nanoid).

1. `shortid` is not maintained anymore (and issue tracker has many [important issues](https://github.com/dylang/shortid/issues)). I tried to took maintenance, but found that I can’t fix `shortid` with keeping API.
2. `nanoid` is just [179 bytes](https://github.com/ai/nanoid/blob/master/package.json#L64-L67). `shortid` is 2 times bigger (about 0.5 KB).
3. `nanoid` is [10x times faster](https://github.com/ai/nanoid#benchmark) than `shortid`.

@serikjensen I kept old ID size, everything will be the same for the user.